### PR TITLE
Allow swapping of where player colors are at the table.

### DIFF
--- a/global-script.lua
+++ b/global-script.lua
@@ -2812,9 +2812,10 @@ function setupPlayerArea(params)
     obj.setVar("playerColor", color)  -- May be nil
     if color then
         obj.createButton({
-            label="Move to here", click_function="onSwapButtonClicked", function_owner=Global,
+            label="Swap with " .. color, click_function="onSwapButtonClicked", function_owner=Global,
             position={0,2.24,-7.2}, rotation={0,180,0}, height=800, width=4000,
-            font_color={0,0,0}, font_size=500, -- hover_color=color,
+            font_color={0,0,0}, font_size=500,
+            tooltip="Moves your current player color to be located here.  The color currently seated here will be moved to your current location.",
         })
     end
 
@@ -3154,10 +3155,6 @@ function swapPlayerAreas(a, b)
     local function tintSwap(table)
         local oa = table[a]
         local ob = table[b]
-        if type(oa) == "string" then
-            oa = getObjectFromGUID(oa)
-            ob = getObjectFromGUID(ob)
-        end
         local ta = oa.getColorTint()
         local tb = ob.getColorTint()
         oa.setColorTint(tb)
@@ -3176,8 +3173,16 @@ function swapPlayerAreas(a, b)
         oa.setPosition(tb)
         ob.setPosition(ta)
     end
+    local function updateBlock(color)
+        local o = playerBlocks[color]
+        if not o then
+            return 
+        end
+        o.setVar("playerColor", color)
+        o.editButton({index=1, label="Swap with " .. color})
+    end
 
-    print("Player " .. a .. " is trading places with player " .. b .. ".")
+    print(a .. " is trading places with player " .. b .. ".")
     for i = 1,2 do
         local ta = Player[a].getHandTransform(i)
         local tb = Player[b].getHandTransform(i)
@@ -3189,8 +3194,8 @@ function swapPlayerAreas(a, b)
     positionSwap(defendBags)
     positionSwap(readyTokens)
     tableSwap(elementScanZones)
-    if playerBlocks[a] then playerBlocks[a].setVar("playerColor", a) end
-    if playerBlocks[b] then playerBlocks[b].setVar("playerColor", b) end
+    updateBlock(a)
+    updateBlock(b)
 end
 
 

--- a/global-script.lua
+++ b/global-script.lua
@@ -2808,7 +2808,7 @@ function setupPlayerArea(params)
     if color then
         obj.createButton({
             label="Swap with " .. color, click_function="onSwapButtonClicked", function_owner=Global,
-            position={0,2.24,-7.2}, rotation={0,180,0}, height=800, width=4000,
+            position={0,2.24,-24.7}, rotation={0,180,0}, height=800, width=4000,
             font_color={0,0,0}, font_size=500,
             tooltip="Moves your current player color to be located here.  The color currently seated here will be moved to your current location.",
         })
@@ -3197,7 +3197,7 @@ function swapPlayerAreas(a, b)
     updateBlock(a)
     updateBlock(b)
 
-    print(a .. " traded places with " .. b .. ".")
+    print(a .. " swapped places with " .. b .. ".")
 end
 
 

--- a/global-script.lua
+++ b/global-script.lua
@@ -45,6 +45,22 @@ explorerBag = "613ea4"
 townBag = "4d3c15"
 cityBag = "a245f8"
 selectedColors = {}
+playerTables = {
+    Red = "dce473",
+    Purple = "c99d4d",
+    Yellow = "794c81",
+    Blue = "125e82",
+    Green = "d7d593",
+    Orange = "33c4af",
+}
+playerBlocks = {
+    Red = "c68e2c",
+    Purple = "661aa3",
+    Yellow = "c3c59b",
+    Blue = "36bbcc",
+    Green = "fac8e4",
+    Orange = "6b5b4b",
+}
 ------ Unsaved Config Data
 numPlayers = 1
 numBoards = 1
@@ -133,23 +149,6 @@ readyTokens = {
     Green = "88a4c3",
     Orange = "d17f93",
 }
-playerTables = {
-    Red = "dce473",
-    Purple = "c99d4d",
-    Yellow = "794c81",
-    Blue = "125e82",
-    Green = "d7d593",
-    Orange = "33c4af",
-}
-playerBlocks = {
-    Red = "c68e2c",
-    Purple = "661aa3",
-    Yellow = "c3c59b",
-    Blue = "36bbcc",
-    Green = "fac8e4",
-    Orange = "6b5b4b",
-}
-
 interactableObjectsToDisableOnLoad = {
     "57dbb8","fd27d5","25fddc", "d3dd7e", -- tables
     "dce473","c99d4d","794c81","125e82","d7d593","33c4af", -- player tables

--- a/global-script.lua
+++ b/global-script.lua
@@ -3169,6 +3169,12 @@ function swapPlayerAreas(a, b)
         oa.setPosition(tb)
         ob.setPosition(ta)
     end
+    local function handSwap(i)
+        local ta = Player[a].getHandTransform(i)
+        local tb = Player[b].getHandTransform(i)
+        Player[a].setHandTransform(tb, i)
+        Player[b].setHandTransform(ta, i)
+    end
     local function updateBlock(color)
         local o = playerBlocks[color]
         if not o then
@@ -3178,12 +3184,8 @@ function swapPlayerAreas(a, b)
         o.editButton({index=1, label="Swap with " .. color})
     end
 
-    print(a .. " is trading places with player " .. b .. ".")
     for i = 1,2 do
-        local ta = Player[a].getHandTransform(i)
-        local tb = Player[b].getHandTransform(i)
-        Player[a].setHandTransform(tb, i)
-        Player[b].setHandTransform(ta, i)
+        handSwap(i)
     end
     tintSwap(playerTables)
     tableSwap(playerBlocks)
@@ -3192,6 +3194,8 @@ function swapPlayerAreas(a, b)
     tableSwap(elementScanZones)
     updateBlock(a)
     updateBlock(b)
+
+    print(a .. " traded places with " .. b .. ".")
 end
 
 

--- a/global-script.lua
+++ b/global-script.lua
@@ -319,13 +319,9 @@ function onLoad(saved_data)
     if saved_data ~= "" then
         local loaded_data = JSON.decode(saved_data)
         gameStarted = loaded_data.gameStarted
-        if loaded_data.playerBlocks then
-            playerBlocks = loaded_data.playerBlocks
-            playerTables = loaded_data.playerTables
-        end
-        if loaded_data.elementScanZones then
-            elementScanZones = loaded_data.elementScanZones
-        end
+        playerBlocks = loaded_data.playerBlocks
+        playerTables = loaded_data.playerTables
+        elementScanZones = loaded_data.elementScanZones
         if gameStarted then
             BnCAdded = loaded_data.BnCAdded
             JEAdded = loaded_data.JEAdded
@@ -932,7 +928,7 @@ function CreatePickPowerButton(card, clickFunctionName)
     })
 end
 function PickPowerMinor(cardo,playero,alt_click)
-    -- Give card to player regardless of who's hand they are in front of
+    -- Give card to player regardless of whose hand they are in front of
     cardo.deal(1,playero)
     cardo.clearButtons()
 
@@ -946,7 +942,7 @@ function PickPowerMinor(cardo,playero,alt_click)
     end, function() return not cardo.isSmoothMoving() end)
 end
 function PickPowerMajor(cardo,playero,alt_click)
-    -- Give card to player regardless of who's hand they are in front of
+    -- Give card to player regardless of whose hand they are in front of
     cardo.deal(1,playero)
     cardo.clearButtons()
 
@@ -3206,9 +3202,9 @@ function onSwapButtonClicked(target_obj, source_color, alt_click)
     source_obj = playerBlocks[source_color]
 
     if not target_color then
-        player.print("That seat is already taken.")
+        broadcastToColor("That seat is already taken.", source_color)
     elseif not source_obj then
-        player.print("You are already seated.")
+        broadcastToColor("You have already chosen a spirit.", source_color)
     elseif target_color == source_color then
         -- player.print("Okay, you trade places with yourself.")
     else

--- a/global-script.lua
+++ b/global-script.lua
@@ -3143,6 +3143,9 @@ function tCompare(t1,t2)
 end
 
 function swapPlayerAreas(a, b)
+    if a == b then
+        return  -- Nothing to do!
+    end
     local function tableSwap(table)
         local temp = table[a]
         table[a] = table[b]
@@ -3209,8 +3212,6 @@ function onSwapButtonClicked(target_obj, source_color, alt_click)
         broadcastToColor("That seat is already taken.", source_color)
     elseif not source_obj then
         broadcastToColor("You have already chosen a spirit.", source_color)
-    elseif target_color == source_color then
-        -- player.print("Okay, you trade places with yourself.")
     else
         swapPlayerAreas(source_color, target_color)
     end

--- a/script-state.json
+++ b/script-state.json
@@ -5,6 +5,14 @@
   "BnCAdded": false,
   "cityBag": "a245f8",
   "difficultyString": "",
+  "elementScanZones": {
+    "Blue": "6f2249",
+    "Green": "190f05",
+    "Orange": "61ac7c",
+    "Purple": "654ab2",
+    "Red": "9fc5a4",
+    "Yellow": "102771"
+  },
   "explorerBag": "613ea4",
   "fearPool": 0,
   "gameStarted": false,
@@ -15,6 +23,22 @@
   "panelReadyVisibility": "Invisible",
   "panelTimePassesVisibility": "Invisible",
   "panelTurnOrderVisibility": "Invisible",
+  "playerBlocks": {
+    "Blue": "36bbcc",
+    "Green": "fac8e4",
+    "Orange": "6b5b4b",
+    "Purple": "661aa3",
+    "Red": "c68e2c",
+    "Yellow": "c3c59b"
+  },
+  "playerTables": {
+    "Blue": "125e82",
+    "Green": "d7d593",
+    "Orange": "33c4af",
+    "Purple": "c99d4d",
+    "Red": "dce473",
+    "Yellow": "794c81"
+  },
   "returnBlightBag": "af50b8",
   "selectedColors": [],
   "townBag": "4d3c15"


### PR DESCRIPTION
This allows players to swap which color is seated where at the table by swapping around things including tints of the player table, defend tokens, etc., as previously discussed on Discord.

Players cannot change locations once they have picked a spirit or began a game.  The former is a limitation we could lift later; I just didn't feel like writing code to move everything in the player area to the new location.