### PR TITLE
Fix colorswapping with existing players.

### DIFF
--- a/global-script.lua
+++ b/global-script.lua
@@ -3601,8 +3601,8 @@ function swapPlayerColors(a, b)
             local tempColor
             for _,tempColor in ipairs({"Brown", "Teal", "Pink", "White", "Red", "Orange", "Yellow", "Green", "Blue", "Purple", "Black"}) do
                 if pa.changeColor(tempColor) then
-                    Wait.frames(function() pb.ChangeColor(a) end, 1)
-                    Wait.frames(function() Player[tempColor].ChangeColor(b) end, 2)
+                    Wait.frames(function() pb.changeColor(a) end, 1)
+                    Wait.frames(function() Player[tempColor].changeColor(b) end, 2)
                     return true
                 end
             end

--- a/global-script.lua
+++ b/global-script.lua
@@ -3601,8 +3601,8 @@ function swapPlayerColors(a, b)
             local tempColor
             for _,tempColor in ipairs({"Brown", "Teal", "Pink", "White", "Red", "Orange", "Yellow", "Green", "Blue", "Purple", "Black"}) do
                 if pa.changeColor(tempColor) then
-                    pb.changeColor(a)
-                    pa.changeColor(b)
+                    Wait.frames(function() pb.ChangeColor(a) end, 1)
+                    Wait.frames(function() Player[tempColor].ChangeColor(b) end, 2)
                     return true
                 end
             end
@@ -3679,5 +3679,7 @@ function onPlayerConnect(player)
     updatePlayerArea(player.color)
 end
 function onPlayerDisconnect(player)
-    updatePlayerArea(player.color)
+    if #Player.getPlayers() or #Player.getSpectators() then
+        updatePlayerArea(player.color)
+    end
 end


### PR DESCRIPTION
Tabletop simulator doesn't like players changing colors more than once a frame, and the old code changed the wrong player to boot.  To fix this, when swapping two player colors (which requires 3 color changes):

- Wait 1 frame for the second color change
- Wait 2 frames (one more frame) for the second color change.

Also skip updating the player area if no players or spectators are present, which hopefully should reduce some error spam when leaving games.