### PR TITLE
Remove uses of `broadcastToColor` in favor of `Player[color].broadcast`.

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -13,15 +13,14 @@ read_globals = {
     "addHotkey",
     "broadcastToAll",
     "clearHotkeys",
+    "destroyObject",
     "getAllObjects",
     "getObjectFromGUID",
     "getObjectsWithTag",
+    "group",
     "printToAll",
     "setLookingForPlayers",
     "startLuaCoroutine",
-    "destroyObject",
-    "group",
-    "broadcastToColor",
 }
 -- Additionally `self` is defined for object scripts, and it has mutable fields.
 files["objects/**/*.lua"] = {

--- a/global-script.lua
+++ b/global-script.lua
@@ -4074,7 +4074,7 @@ function moveObjectToHand(card, playerColor, handIndex)
         elseif handTransform.right.z == 1 then
             moveTo.z = moveTo.z + handTransform.scale.z/2
         else
-            broadcastToColor("Couldn't determine left-to-right direction for hand.", playerColor, Color.Red)
+            Player[playerColor]("Couldn't determine left-to-right direction for hand.", Color.Red)
             return
         end
         card.setPosition(moveTo)

--- a/objects/dae0de/script.lua
+++ b/objects/dae0de/script.lua
@@ -15,7 +15,7 @@ end
 
 function getPowerCards(_, color)
     if not Global.getVar("gameStarted") then
-        broadcastToColor("Please wait for the game to start before pressing button!", color, "Red")
+        Player[color].broadcast("Please wait for the game to start before pressing button!", Color.Red)
         return
     end
 
@@ -29,7 +29,7 @@ function getPowerCards(_, color)
        end
     end
     if not found then
-        broadcastToColor("You have not picked Fractured Days Split the Sky!", color, "Red")
+        Player[color].broadcast("You have not picked Fractured Days Split the Sky!", Color.Red)
         return
     end
 
@@ -38,7 +38,7 @@ function getPowerCards(_, color)
         count = 6
     end
     if Global.call("getMapCount", {norm = true, them = true}) == 1 then
-        broadcastToColor("Don't forget to gain 1 Time", color, "Blue")
+        Player[color].broadcast("Don't forget to gain 1 Time", Color.Blue)
     end
     local minorPowerDeck = getObjectFromGUID(Global.getVar("minorPowerZone")).getObjects()[1]
     for _=1,count do


### PR DESCRIPTION
This also sorts the list of globals in the luacheck config.