### PR TITLE
Close all setup panels on load, if the game is started.

### DIFF
--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -77,7 +77,7 @@ function onLoad(saved_data)
     Color.Add("SoftBlue", Color.new(0.45,0.6,0.7))
     Color.Add("SoftYellow", Color.new(0.9,0.7,0.1))
     if Global.getVar("gameStarted") then
-        self.UI.hide("panelSetup")
+        closeUI()
         setupStarted = true
     end
     if saved_data ~= "" then


### PR DESCRIPTION
Currently, the adversary/scenario pnael is still shown on load.