### PR TITLE
Adjust capitalization of spirit names.

### DIFF
--- a/objects/013dfc/object.json
+++ b/objects/013dfc/object.json
@@ -11,7 +11,7 @@
     "scaleY": 1.0,
     "scaleZ": 5.46
   },
-  "Nickname": "Fractured Days Split The Sky",
+  "Nickname": "Fractured Days Split the Sky",
   "Description": "JE",
   "GMNotes": "",
   "ColorDiffuse": {

--- a/objects/72de5c/object.json
+++ b/objects/72de5c/object.json
@@ -11,7 +11,7 @@
     "scaleY": 1.0,
     "scaleZ": 5.46
   },
-  "Nickname": "Vengeance As A Burning Plague",
+  "Nickname": "Vengeance as a Burning Plague",
   "Description": "JE",
   "GMNotes": "",
   "ColorDiffuse": {

--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -752,7 +752,7 @@ function loadConfig()
 end
 function PickSpirit(name, aspect)
     for _,spirit in pairs(getObjectsWithTag("Spirit")) do
-        if spirit.getName() == name then
+        if spirit.getName():lower() == name:lower() then
             if isSpiritPickable({guid = spirit.guid}) then
                 local color = Global.call("getEmptySeat", {})
                 if color ~= nil then

--- a/objects/a576cc/object.json
+++ b/objects/a576cc/object.json
@@ -11,7 +11,7 @@
     "scaleY": 1.0,
     "scaleZ": 5.46
   },
-  "Nickname": "Many Minds Move As One",
+  "Nickname": "Many Minds Move as One",
   "Description": "JE",
   "GMNotes": "",
   "ColorDiffuse": {

--- a/objects/b35fd5/object.json
+++ b/objects/b35fd5/object.json
@@ -11,7 +11,7 @@
     "scaleY": 1.0,
     "scaleZ": 5.46
   },
-  "Nickname": "Lure of The Deep Wilderness",
+  "Nickname": "Lure of the Deep Wilderness",
   "Description": "JE",
   "GMNotes": "",
   "ColorDiffuse": {

--- a/objects/bd2a4a/object.json
+++ b/objects/bd2a4a/object.json
@@ -11,7 +11,7 @@
     "scaleY": 1.0,
     "scaleZ": 5.46
   },
-  "Nickname": "Shadows Flicker like Flame",
+  "Nickname": "Shadows Flicker Like Flame",
   "Description": "Base",
   "GMNotes": "",
   "ColorDiffuse": {


### PR DESCRIPTION
This matches the names used in the community challenge spreadsheet, and for the
ones I could find in the rules books the capitalization there.

This also changes the pick spirit code to be case insensitive.