### PR TITLE
Add tips for players, especially first-time players

### DIFF
--- a/TIPS.md
+++ b/TIPS.md
@@ -6,11 +6,22 @@ Instructions for play
 - To look at the reverse side of your spirit panel press Alt+Shift (default keybinding in TTS) and mouse over the spirit panel 
 - To zoom in on a card hold the Alt key (default keybinding in TTS) and mouse over the card/object
 
+Troubleshooting Tips:
+- Some of my items are plain white, or yellow/black hazard markings
+  - Go to Menu -> Configuration -> General and untick "Mod Caching" then reload your mod. Once your mod is successfully loaded, go turn Mod Caching back on again.
+- The mod is stuck at x% and won't load anymore
+  - You've run out of memory. While TTS minimum is 4GB, the Spirit Island mod requires more than this, 8GB advised. If you've got less than 4GB ram, or are playing on a 32-bit operating system, you cannot play this mod.
+- The camera behaves strangely
+  - Press P, or right-click off the table to change your camera mode. 3rd Person is recommended. You can press spacebar to return to your default camera position.
+- A board is rotated or sized incorrectly for some players
+  - Either the player with the issues can reconnect or someone who sees the board properly can use the gizmo tool to change the rotation/scale by 0.01
+- To discard cards, right click and select discard. Reclaim, by selecting the card(s) from the discard zone (below your cards in hand area) and drag them up.
+
 Intermediate Tips:
 - Press numpad keys (as shown in the bottom right) to spawn new pieces
   - Make sure numlock is enabled
   - Note that these scripting keys can be rebound in the TTS settings
-- Lock pieces (right-click and select lock)
+- Lock pieces (hover over the piece and right-click->Toggles->Lock or press "L")
 - Mark damage on pieces by changing the state
   - i.e. to mark one damage on a town, right click the town and change the state to 2
   - You can also press a number key to change the state (so press 2 to change the state to 2)
@@ -18,14 +29,26 @@ Intermediate Tips:
 - Defend values can also be set as a state
 - To prevent a piece from going away during time passes you should lock it (right-click and select lock)
 - You can use energy tokens instead of the counter by deleting the energy counter (right-click on the energy counter and press delete)
+  - Note that deleting requires you to be the host or to be promoted
+- When removing blight from the blight card (usually for an event), move it to the "box" to the top-left of the play area (instead of deleting it)
+- When you have dealt enough damage to an invader to destroy it, drag it from the island board onto the "play mat" and add the corresponding amount of fear to the fear pool. 
+  - This has to be manual because some events change the amount of fear that you generate
   
 Advanced Tips:
 - UI elements can be enabled and disabled with the little triangle near the top-right of your screen
 - You can play double-handed (i.e. play 2 or more spirits) by changing your TTS player color in the top-right of the screen and choosing another spirit
   - Note that your UI elements are tracked per spirit
-- You can bind keys to many other actions with options->keys (TODO check name)
-- When playing as Shroud of Silent Mist it's important to not heal invaders and dahan in its land when time passes
-  - You can do this by locking the bottom invader in a stack or by stacking the damaged invader on top of a scenario token
+- You can bind keys to many other actions with Options (near the top-middle of the screen) -> Game Keys
 - If you play thresholded "Cast Down Into the Briny Deeps" use the gizmo tool (one of the tools on the left side of the screen) to move the island board
 - You can choose what island boards to play with at setup by placing the island boards before starting your game
 - To change what spirit you're playing after you've already started the game either reload the mod to restart everything, or unlock the spirit panel (right-click and press lock) and delete the spirit panel and any extra tokens/cards it has (right-click and select delete), then drag over a new spirit panel.
+- To play with an archipelago map, grab the map tiles from the box, which is to the left of the setup buttons, and then place them onto the map. When you hit Start Game after choosing your options the mod will set things up for you
+  - You probably want to hit the "Hide UI" button in the setup area to see more clearly where you are putting the boards
+  - This holds true for any custom map setup you want to do
+- To use save files posted in the Discord channel, download the JSON file and put it into your TTS saves folder: My Documents/My Games/Tabletop Simulator/Saves
+- If you play "Unlock The Gates of Deepest Power" you can right-click the "Gain a Major" button to draw two major powers
+
+Spirit-Specific tips:
+- When playing as Shroud of Silent Mist it's important to not heal invaders and dahan in its land when time passes
+  - You can do this by locking the bottom invader in a stack or by stacking the damaged invader on top of a scenario token
+- When playing Stalight Seeks Its Form and playing "Boon of Reimagining" you can right-click the "Gain a minor power" to draw 6 minors and gain two of them

--- a/TIPS.md
+++ b/TIPS.md
@@ -1,0 +1,31 @@
+Instructions for play
+
+- While some parts of the mod are scripted, many parts (such as exploring and building/placing of invaders after setup) are not
+- When playing single player you can ignore the ready token and the "ready" text at the upper right (it's used for coordination among players)
+- Do not hit the rewind/fastforward (they do not work well with scripted mods)
+- To look at the reverse side of your spirit panel press Alt+Shift (default keybinding in TTS) and mouse over the spirit panel 
+- To zoom in on a card hold the Alt key (default keybinding in TTS) and mouse over the card/object
+
+Intermediate Tips:
+- Press numpad keys (as shown in the bottom right) to spawn new pieces
+  - Make sure numlock is enabled
+  - Note that these scripting keys can be rebound in the TTS settings
+- Lock pieces (right-click and select lock)
+- Mark damage on pieces by changing the state
+  - i.e. to mark one damage on a town, right click the town and change the state to 2
+  - You can also press a number key to change the state (so press 2 to change the state to 2)
+  - Note that invaders that have extra health or deal extra damage are rendered in a different color (i.e. red for england buildings, and blue for russian explorers)
+- Defend values can also be set as a state
+- To prevent a piece from going away during time passes you should lock it (right-click and select lock)
+- You can use energy tokens instead of the counter by deleting the energy counter (right-click on the energy counter and press delete)
+  
+Advanced Tips:
+- UI elements can be enabled and disabled with the little triangle near the top-right of your screen
+- You can play double-handed (i.e. play 2 or more spirits) by changing your TTS player color in the top-right of the screen and choosing another spirit
+  - Note that your UI elements are tracked per spirit
+- You can bind keys to many other actions with options->keys (TODO check name)
+- When playing as Shroud of Silent Mist it's important to not heal invaders and dahan in its land when time passes
+  - You can do this by locking the bottom invader in a stack or by stacking the damaged invader on top of a scenario token
+- If you play thresholded "Cast Down Into the Briny Deeps" use the gizmo tool (one of the tools on the left side of the screen) to move the island board
+- You can choose what island boards to play with at setup by placing the island boards before starting your game
+- To change what spirit you're playing after you've already started the game either reload the mod to restart everything, or unlock the spirit panel (right-click and press lock) and delete the spirit panel and any extra tokens/cards it has (right-click and select delete), then drag over a new spirit panel.


### PR DESCRIPTION
These tips are not meant to be read in the GitHub repository but I'm not familiar enough with TTS modding to add code to display them in game.

But I imagine that the basic instructions for play would be shown as part of the game setup UI, and also be available near the rule-book area (where they would be combined with the intermediate and advanced tips). Possibly collapsible/toggleable text would be used to toggle the visibility of the intermediate and advanced tips.

More tips are welcome, these are just the ones that I could think of initially.