### PR TITLE
Adjust the code that updates the turn order UI to be more robust.

### DIFF
--- a/script.lua
+++ b/script.lua
@@ -6941,7 +6941,7 @@ function updateCurrentPhase(clear)
         textColor = "#323232"
     }
     if clear then
-        attributes.text = string.sub(UI.getAttribute(id, "text"), 3, -3)
+        attributes.text = string.gsub(string.gsub(UI.getAttribute(id, "text"), ">>", ""), "<<", "")
     else
         attributes.text = ">>"..UI.getAttribute(id, "text").."<<"
     end


### PR DESCRIPTION
It was reported that the turn order UI text could get mangled, replacing
"Fast Power Phase" with "st Power Pha". I suspect this is because the code
to remove >> << from around the phase was being run twice, removing two more
characters from each end. Changing it to find-and-replace the >> << out
should make it robust against this.