### PR TITLE
Add the "maximise adversary level" setup option.

### DIFF
--- a/objects/SetupChecker/script-state.json
+++ b/objects/SetupChecker/script-state.json
@@ -140,6 +140,7 @@
     "board": false,
     "max": 11,
     "min": 0,
+    "maxLevel": false,
     "scenario": false,
     "thematic": false
   },

--- a/objects/SetupChecker/script-state.json
+++ b/objects/SetupChecker/script-state.json
@@ -140,7 +140,7 @@
     "board": false,
     "max": 11,
     "min": 0,
-    "maxLevel": false,
+    "maximiseLevel": false,
     "scenario": false,
     "thematic": false
   },

--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -42,7 +42,7 @@ weeklyChallenge = false
 
 randomMin = 0
 randomMax = 11
-randomMaxLevel = false
+randomMaximiseLevel = false
 randomAdversary = false
 randomAdversary2 = false
 randomScenario = false
@@ -129,7 +129,7 @@ function onSave()
     data_table.random = {}
     data_table.random.min = randomMin
     data_table.random.max = randomMax
-    data_table.random.maxLevel = randomMaxLevel
+    data_table.random.maximiseLevel = randomMaximiseLevel
     data_table.random.adversary = randomAdversary
     data_table.random.adversary2 = randomAdversary2
     data_table.random.scenario = randomScenario
@@ -207,7 +207,7 @@ function onLoad(saved_data)
 
         randomMin = loaded_data.random.min
         randomMax = loaded_data.random.max
-        randomMaxLevel = loaded_data.random.maxLevel
+        randomMaximiseLevel = loaded_data.random.maximiseLevel
         randomAdversary = loaded_data.random.adversary
         randomAdversary2 = loaded_data.random.adversary2
         randomScenario = loaded_data.random.scenario
@@ -284,7 +284,7 @@ function onLoad(saved_data)
 
             toggleMinDifficulty(nil, randomMin)
             toggleMaxDifficulty(nil, randomMax)
-            self.UI.setAttribute("maxLevelToggle", "isOn", randomMaxLevel)
+            self.UI.setAttribute("maximiseLevelToggle", "isOn", randomMaximiseLevel)
             if randomAdversary or randomAdversary2 or randomScenario then
                 enableRandomDifficulty()
             end
@@ -1738,16 +1738,16 @@ function toggleMaxDifficulty(_, value)
     self.UI.setAttribute("maxDifficulty", "text", "Max Random Difficulty: "..randomMax)
     self.UI.setAttribute("maxDifficultySlider", "value", randomMax)
 end
-function toggleMaxLevel()
-    randomMaxLevel = not randomMaxLevel
-    self.UI.setAttribute("maxLevelToggle", "isOn", randomMaxLevel)
+function toggleMaximiseLevel()
+    randomMaximiseLevel = not randomMaximiseLevel
+    self.UI.setAttribute("maximiseLevelToggle", "isOn", randomMaximiseLevel)
 end
 function enableRandomDifficulty()
     self.UI.setAttribute("minTextRow", "visibility", "")
     self.UI.setAttribute("minRow", "visibility", "")
     self.UI.setAttribute("maxTextRow", "visibility", "")
     self.UI.setAttribute("maxRow", "visibility", "")
-    self.UI.setAttribute("maxLevelRow", "visibility", "")
+    self.UI.setAttribute("maximiseLevelRow", "visibility", "")
 end
 function checkRandomDifficulty(enable, force)
     local visibility = ""
@@ -1760,7 +1760,7 @@ function checkRandomDifficulty(enable, force)
         self.UI.setAttribute("minRow", "visibility", visibility)
         self.UI.setAttribute("maxTextRow", "visibility", visibility)
         self.UI.setAttribute("maxRow", "visibility", visibility)
-        self.UI.setAttribute("maxLevelRow", "visibility", visibility)
+        self.UI.setAttribute("maximiseLevelRow", "visibility", visibility)
     end
 end
 

--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -42,6 +42,7 @@ weeklyChallenge = false
 
 randomMin = 0
 randomMax = 11
+randomMaxLevel = false
 randomAdversary = false
 randomAdversary2 = false
 randomScenario = false
@@ -128,6 +129,7 @@ function onSave()
     data_table.random = {}
     data_table.random.min = randomMin
     data_table.random.max = randomMax
+    data_table.random.maxLevel = randomMaxLevel
     data_table.random.adversary = randomAdversary
     data_table.random.adversary2 = randomAdversary2
     data_table.random.scenario = randomScenario
@@ -205,6 +207,7 @@ function onLoad(saved_data)
 
         randomMin = loaded_data.random.min
         randomMax = loaded_data.random.max
+        randomMaxLevel = loaded_data.random.maxLevel
         randomAdversary = loaded_data.random.adversary
         randomAdversary2 = loaded_data.random.adversary2
         randomScenario = loaded_data.random.scenario
@@ -281,6 +284,7 @@ function onLoad(saved_data)
 
             toggleMinDifficulty(nil, randomMin)
             toggleMaxDifficulty(nil, randomMax)
+            self.UI.setAttribute("maxLevelToggle", "isOn", randomMaxLevel)
             if randomAdversary or randomAdversary2 or randomScenario then
                 enableRandomDifficulty()
             end
@@ -1734,11 +1738,16 @@ function toggleMaxDifficulty(_, value)
     self.UI.setAttribute("maxDifficulty", "text", "Max Random Difficulty: "..randomMax)
     self.UI.setAttribute("maxDifficultySlider", "value", randomMax)
 end
+function toggleMaxLevel()
+    randomMaxLevel = not randomMaxLevel
+    self.UI.setAttribute("maxLevelToggle", "isOn", randomMaxLevel)
+end
 function enableRandomDifficulty()
     self.UI.setAttribute("minTextRow", "visibility", "")
     self.UI.setAttribute("minRow", "visibility", "")
     self.UI.setAttribute("maxTextRow", "visibility", "")
     self.UI.setAttribute("maxRow", "visibility", "")
+    self.UI.setAttribute("maxLevelRow", "visibility", "")
 end
 function checkRandomDifficulty(enable, force)
     local visibility = ""
@@ -1751,6 +1760,7 @@ function checkRandomDifficulty(enable, force)
         self.UI.setAttribute("minRow", "visibility", visibility)
         self.UI.setAttribute("maxTextRow", "visibility", visibility)
         self.UI.setAttribute("maxRow", "visibility", visibility)
+        self.UI.setAttribute("maxLevelRow", "visibility", visibility)
     end
 end
 

--- a/objects/SetupChecker/ui.xml
+++ b/objects/SetupChecker/ui.xml
@@ -125,8 +125,8 @@
             <Row id="maxRow" visibility="Invisible">
                 <Cell columnSpan="2"><Slider id="maxDifficultySlider" minValue="0" maxValue="28" value="11" onValueChanged="toggleMaxDifficulty"/></Cell>
             </Row>
-            <Row id="maxLevelRow" class="toggle"  visibility="Invisible">
-                <Cell columnSpan="2"><Toggle id="maxLevelToggle" onValueChanged="toggleMaxLevel" tooltip="After randomly selecting an Adversary, maximise its level&#xA;while remaining within the selected difficulty range">Maximise Adversary level in range</Toggle></Cell>
+            <Row id="maximiseLevelRow" class="toggle"  visibility="Invisible">
+                <Cell columnSpan="2"><Toggle id="maximiseLevelToggle" onValueChanged="toggleMaximiseLevel" tooltip="After randomly selecting an Adversary, maximise its level&#xA;while remaining within the selected difficulty range">Maximise Adversary level in range</Toggle></Cell>
             </Row>
             <Row id="simpleRow" class="toggle" visibility="Invisible">
                 <Cell><Toggle id="blightCard2" isOn="true" onValueChanged="toggleBlightCard">Use Blight Card</Toggle></Cell>

--- a/objects/SetupChecker/ui.xml
+++ b/objects/SetupChecker/ui.xml
@@ -125,6 +125,9 @@
             <Row id="maxRow" visibility="Invisible">
                 <Cell columnSpan="2"><Slider id="maxDifficultySlider" minValue="0" maxValue="28" value="11" onValueChanged="toggleMaxDifficulty"/></Cell>
             </Row>
+            <Row id="maxLevelRow" class="toggle"  visibility="Invisible">
+                <Cell columnSpan="2"><Toggle id="maxLevelToggle" onValueChanged="toggleMaxLevel" tooltip="After randomly selecting an Adversary, maximise its level&#xA;while remaining within the selected difficulty range">Maximise Adversary level in range</Toggle></Cell>
+            </Row>
             <Row id="simpleRow" class="toggle" visibility="Invisible">
                 <Cell><Toggle id="blightCard2" isOn="true" onValueChanged="toggleBlightCard">Use Blight Card</Toggle></Cell>
                 <Cell><Toggle id="allEvents" isOn="true" onValueChanged="toggleAllEvents">Use Events</Toggle></Cell>
@@ -169,7 +172,7 @@
         </TableLayout>
     </VerticalLayout>
 </Panel>
-<Panel id="panelVariant" recurse="events" visibility="Invisible" width="1000" height="2800" position="-2000 -3080 14">
+<Panel id="panelVariant" recurse="events" visibility="Invisible" width="1000" height="2800" position="-2000 -3160 14">
     <VerticalLayout recurse="events">
         <TableLayout recurse="events">
             <Row class="header">

--- a/script.lua
+++ b/script.lua
@@ -1096,7 +1096,7 @@ function randomAdversary(attempts)
         local difficulty2 = adversary2.getVar("difficulty")
         local randomMin = SetupChecker.getVar("randomMin")
         local randomMax = SetupChecker.getVar("randomMax")
-        local randomMaxLevel = SetupChecker.getVar("randomMaxLevel")
+        local randomMaximiseLevel = SetupChecker.getVar("randomMaximiseLevel")
         local combos = {}
         for i,v in pairs(difficulty) do
             local params = {lead = v}
@@ -1110,7 +1110,7 @@ function randomAdversary(attempts)
                 if difficulty2[j+1] ~= nil and SetupChecker.call("difficultyCheck", {lead = v, support = difficulty2[j+1]}) <= randomMax then
                     canIncreaseLevel = true
                 end
-                if newDiff >= randomMin and newDiff <= randomMax and not (randomMaxLevel and canIncreaseLevel) then
+                if newDiff >= randomMin and newDiff <= randomMax and not (randomMaximiseLevel and canIncreaseLevel) then
                     table.insert(combos, {i,j})
                 elseif newDiff > randomMax then
                     break
@@ -1151,7 +1151,7 @@ function randomAdversary(attempts)
 
         local randomMin = SetupChecker.getVar("randomMin")
         local randomMax = SetupChecker.getVar("randomMax")
-        local randomMaxLevel = SetupChecker.getVar("randomMaxLevel")
+        local randomMaximiseLevel = SetupChecker.getVar("randomMaximiseLevel")
         local combos = {}
         for i,v in pairs(adversary.getVar("difficulty")) do
             local params = {}
@@ -1169,7 +1169,7 @@ function randomAdversary(attempts)
         end
         if #combos ~= 0 then
             local index
-            if randomMaxLevel then
+            if randomMaximiseLevel then
                 index = #combos
             else
                 index = math.random(1,#combos)

--- a/script.lua
+++ b/script.lua
@@ -1096,13 +1096,21 @@ function randomAdversary(attempts)
         local difficulty2 = adversary2.getVar("difficulty")
         local randomMin = SetupChecker.getVar("randomMin")
         local randomMax = SetupChecker.getVar("randomMax")
+        local randomMaxLevel = SetupChecker.getVar("randomMaxLevel")
         local combos = {}
         for i,v in pairs(difficulty) do
             local params = {lead = v}
             for j,w in pairs(difficulty2) do
                 params.support = w
                 local newDiff = SetupChecker.call("difficultyCheck", params)
-                if newDiff >= randomMin and newDiff <= randomMax then
+                local canIncreaseLevel = false
+                if difficulty[i+1] ~= nil and SetupChecker.call("difficultyCheck", {lead = difficulty[i+1], support = w}) <= randomMax then
+                    canIncreaseLevel = true
+                end
+                if difficulty2[j+1] ~= nil and SetupChecker.call("difficultyCheck", {lead = v, support = difficulty2[j+1]}) <= randomMax then
+                    canIncreaseLevel = true
+                end
+                if newDiff >= randomMin and newDiff <= randomMax and not (randomMaxLevel and canIncreaseLevel) then
                     table.insert(combos, {i,j})
                 elseif newDiff > randomMax then
                     break
@@ -1143,6 +1151,7 @@ function randomAdversary(attempts)
 
         local randomMin = SetupChecker.getVar("randomMin")
         local randomMax = SetupChecker.getVar("randomMax")
+        local randomMaxLevel = SetupChecker.getVar("randomMaxLevel")
         local combos = {}
         for i,v in pairs(adversary.getVar("difficulty")) do
             local params = {}
@@ -1159,7 +1168,12 @@ function randomAdversary(attempts)
             end
         end
         if #combos ~= 0 then
-            local index = math.random(1,#combos)
+            local index
+            if randomMaxLevel then
+                index = #combos
+            else
+                index = math.random(1,#combos)
+            end
             if adversaryCard == nil then
                 adversaryCard = adversary
                 adversaryLevel = combos[index]


### PR DESCRIPTION
It ensures a game which is as close to the top of the selected difficulty range as possible, given the selected adversary/adversaries.

Conveniently, if this is selected with a single random adversary and the default 0-11 difficulty range, it emulates the much-requested "random level 6 adversary".