### PR TITLE
Use Custom UI (instead of Classic UI) for swapping between spirits.

### DIFF
--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -1879,7 +1879,9 @@ function gainSpirit(player)
     local options = {}
     local buttons = obj.getButtons()
     local hasOptions = 0
+    local numButtons = 0
     if buttons ~= nil then
+        numButtons = #buttons
         for i, button in ipairs(buttons) do
             if button.label ~= "" then
                 options[i] = true
@@ -1915,17 +1917,28 @@ function gainSpirit(player)
                 if aspect ~= nil and aspect ~= "" then
                     label = label.." - "..aspect
                 end
-                obj.createButton({
-                    click_function = "pickSpirit" .. i,
-                    function_owner = self,
-                    label = label,
-                    position = Vector(0,3,-5 + 2*i),
-                    rotation = Vector(0,0,0),
-                    scale = Vector(2/2.3,1,2/1.42),
-                    width = 4850,
-                    height = 600,
-                    font_size = 275,
-                })
+                if i > numButtons then
+                    obj.createButton({
+                        click_function = "pickSpirit" .. i,
+                        function_owner = self,
+                        label = label,
+                        position = Vector(0,3,-5 + 2*i),
+                        rotation = Vector(0,0,0),
+                        scale = Vector(2/2.3,1,2/1.42),
+                        width = 4850,
+                        height = 600,
+                        font_size = 275,
+                    })
+                else
+                    obj.editButton({
+                        index = i - 1,
+                        label = label,
+                        width = 4850,
+                        height = 600,
+                    })
+                end
+            else
+                break
             end
         end
     end

--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -1937,8 +1937,6 @@ function gainSpirit(player)
                         height = 600,
                     })
                 end
-            else
-                break
             end
         end
     end

--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -1880,12 +1880,12 @@ function gainSpirit(player)
     local buttons = obj.getButtons()
     local hasOptions = 0
     if buttons ~= nil then
-        for i=4,#buttons do
-            if buttons[i].label ~= "" then
-                options[i-4] = true
+        for i, button in ipairs(buttons) do
+            if button.label ~= "" then
+                options[i] = true
                 hasOptions = hasOptions + 1
             else
-                options[i-4] = false
+                options[i] = false
             end
         end
     end
@@ -1955,19 +1955,19 @@ function getNewSpirit(tags, complexities)
 end
 function pickSpirit1(obj, color)
     if Global.getTable("playerTables")[color] ~= obj then return end
-    pickSpirit(obj, 3, color)
+    pickSpirit(obj, 0, color)
 end
 function pickSpirit2(obj, color)
     if Global.getTable("playerTables")[color] ~= obj then return end
-    pickSpirit(obj, 4, color)
+    pickSpirit(obj, 1, color)
 end
 function pickSpirit3(obj, color)
     if Global.getTable("playerTables")[color] ~= obj then return end
-    pickSpirit(obj, 5, color)
+    pickSpirit(obj, 2, color)
 end
 function pickSpirit4(obj, color)
     if Global.getTable("playerTables")[color] ~= obj then return end
-    pickSpirit(obj, 6, color)
+    pickSpirit(obj, 3, color)
 end
 function replaceSpirit(obj, index, color)
     local tags = getSpiritTags()
@@ -2093,14 +2093,14 @@ function removeSpirit(params)
                 if params.color ~= color then
                     local buttons = obj.getButtons()
                     if buttons ~= nil then
-                        for i=4,#buttons do
-                            local label = buttons[i].label
+                        for _, button in ipairs(buttons) do
+                            local label = button.label
                             local start,_ = string.find(label, " %- ")
                             if start ~= nil then
                                 label = string.sub(label, 1, start-1)
                             end
                             if name == label then
-                                replaceSpirit(obj, i-1, color)
+                                replaceSpirit(obj, button.index, color)
                                 found = true
                                 break
                             end

--- a/script.lua
+++ b/script.lua
@@ -6374,7 +6374,8 @@ function setupSwapButtons(obj)
             width = "270",
             height = "110",
             visibility = playerButtonVisibility,
-            tooltip="Moves your current player color to be located here. The color currently seated here will be moved to your current location. Spirit panels and other cards will be relocated if applicable.",
+            -- Note: tooltips don't work on Custom UI (https://tabletopsimulator.nolt.io/1369)
+            -- tooltip="Moves your current player color to be located here. The color currently seated here will be moved to your current location. Spirit panels and other cards will be relocated if applicable.",
         },
         children = {},
     })
@@ -6392,7 +6393,8 @@ function setupSwapButtons(obj)
             width = "270",
             height = "110",
             visibility = playerButtonVisibility,
-            tooltip="Change to be this color, updating all of your presence and reminder tokens accordingly. The player that is this color will be changed to be yours. Your seating position will not change.",
+            -- Note: tooltips don't work on Custom UI (https://tabletopsimulator.nolt.io/1369)
+            -- tooltip="Change to be this color, updating all of your presence and reminder tokens accordingly. The player that is this color will be changed to be yours. Your seating position will not change.",
         },
         children = {},
     })
@@ -6408,7 +6410,8 @@ function setupSwapButtons(obj)
             width = "270",
             height = "110",
             visibility = playSpiritVisibility,
-            tooltip="Switch to play the spirit that is here, changing your player color accordingly. Only available for spirits without a seated player. Intended for multi-handed solo games.",
+            -- Note: tooltips don't work on Custom UI (https://tabletopsimulator.nolt.io/1369)
+            -- tooltip="Switch to play the spirit that is here, changing your player color accordingly. Only available for spirits without a seated player. Intended for multi-handed solo games.",
         },
         children = {},
     })

--- a/script.lua
+++ b/script.lua
@@ -6338,11 +6338,13 @@ function setupColor(table, color)
     end
     table.setColorTint(colorTint)
     table.clearButtons()
-    setupSwapButtons(table)
+    setupSwapButtons(table, { seated = true })
 
     updateColorPickButtons()
 end
-function setupSwapButtons(obj)
+-- @param params.seated Boolean indicating if a player is about to be seated here.
+function setupSwapButtons(obj, params)
+    params = params or {}
     local xml = {}
     local color = getTableColor(obj)
     local buttonColor = Color[color]:toHex(false)
@@ -6353,7 +6355,7 @@ function setupSwapButtons(obj)
     end
     local playSpiritVisibility = "Invisible"
     local playSpiritText = ""
-    if not Player[color].seated then
+    if not params.seated and not Player[color].seated then
         if selectedColors[color] then
             playSpiritVisibility = visiTableToString(invertVisiTable({color}))
             playSpiritText = "Play Spirit"

--- a/script.lua
+++ b/script.lua
@@ -3604,12 +3604,7 @@ function enableUI()
 
         -- Need to wait for xml table to get updated
         Wait.frames(function()
-            local colors = {}
-            for _,color in pairs(Player.getColors()) do
-                if color ~= "Black" and color ~= "Grey" then
-                    table.insert(colors, color)
-                end
-            end
+            local colors = invertVisiTable({"Black", "Grey"})
             UI.setAttribute("panelUIToggle","active","true")
             setVisiTable("panelTimePasses", colors)
             setVisiTable("panelReady", colors)
@@ -5031,12 +5026,7 @@ function showGameOver()
     refreshGameOver()
 
     if SetupChecker.getVar("optionalGameResults") then
-        local colors = {}
-        for _,color in pairs(Player.getColors()) do
-            if color ~= "Black" and color ~= "Grey" then
-                table.insert(colors, color)
-            end
-        end
+        local colors = invertVisiTable({"Black", "Grey"})
         setVisiTable("panelGameOver", colors)
     end
 end
@@ -6545,6 +6535,24 @@ function getVisiTable(xmlID) return visiStringToTable(UI.getAttribute(xmlID,"vis
 function setVisiTable(xmlID, inTable) UI.setAttribute(xmlID,"visibility",visiTableToString(inTable)) end
 function getVisiTableParams(params) return getVisiTable(params.id) end
 function setVisiTableParams(params) setVisiTable(params.id, params.table) end
+--- Takes a table of player colors and returns a table of all the player colors
+--- not in the argument.
+function invertVisiTable(inTable)
+    local outTable = {}
+    for _, color in pairs(Player.getColors()) do
+        local include = true
+        for _, c in pairs(inTable) do
+            if color == c then
+                include = false
+                break
+            end
+        end
+        if include then
+            table.insert(outTable, color)
+        end
+    end
+    return outTable
+end
 
 function showButtons(player)
     toggleUI("panelUIToggleHide", player.color, false)


### PR DESCRIPTION
The motivation for making this change is that spectators appear to be able to interact with Custom UI, but not Classic UI. This means that the "Play Spirit" button didn't work if you opened a saved game in single player and instead needed to use the builtin color picker.

Since the Custom UI allows controlling visibility per-player, I took advantage of that to not show the UI for yourself, and not show the swap places/colors buttons for spectators.