### PR TITLE
Fix a potential bug with custom adversaries and the invader board UI.

### DIFF
--- a/objects/JEBag/contained/299e38/contained/86c840/script.lua
+++ b/objects/JEBag/contained/299e38/contained/86c840/script.lua
@@ -21,7 +21,7 @@ function removeCards(card)
             for _,obj in pairs(deck.getObjects()) do
                 local start, finish = string.find(obj.lua_script,"cardInvaderStage=")
                 if start ~= nil then
-                    local stage = string.sub(obj.lua_script,finish+1)
+                    local stage = string.sub(obj.lua_script,finish+1,finish+1)
                     if stage == "2" then
                         stage2Guid = obj.guid
                     elseif stage == "3" then

--- a/objects/aidBoard/script.lua
+++ b/objects/aidBoard/script.lua
@@ -620,7 +620,7 @@ function getStage(o)
             end
             if found then
                 local _, finish = string.find(obj.lua_script,"cardInvaderStage=")
-                local stage = tonumber(string.sub(obj.lua_script,finish+1))
+                local stage = tonumber(string.sub(obj.lua_script,finish+1,finish+1))
                 -- Prussia early stage 3 should count as stage 2
                 if string.find(obj.lua_script,"special=") ~= nil then
                     stage = stage - 1

--- a/script.lua
+++ b/script.lua
@@ -3496,7 +3496,7 @@ function PostSetup()
             for _,card in pairs(cards) do
                 local start,finish = string.find(card.lua_script,"cardInvaderStage=")
                 if start ~= nil then
-                    local stage = tonumber(string.sub(card.lua_script,finish+1))
+                    local stage = tonumber(string.sub(card.lua_script,finish+1,finish+1))
                     local special = string.find(card.lua_script,"special=")
                     if special ~= nil then
                         stage = stage - 1


### PR DESCRIPTION
The aidBoard getStage() function, when taking a substring of an invader card's lua script in order to find that invader card's stage, would take the entire script from the end of "cardInvaderStage=" to the end of the script. This required the definition of cardInvaderStage to be the final line of the script in order to work properly, and thus could break on custom adversaries with custom invader cards that include extra scripting. This is easily fixed by only taking one character (stage numbers are always one digit), instead of all characters to the end of the script.