### PR TITLE
Fix a bug where spirit-specific setup items didn't work if moved to the wrong spirit first.

### DIFF
--- a/CUSTOM.md
+++ b/CUSTOM.md
@@ -346,6 +346,7 @@ This section is meant for users who are familiar with both the tts mod and progr
   - `doSetup(params)`
     - `params`: **table** - contains data about player
       - `color`: **string** - is the color of the player who picked the spirit
+    - return **bool** - was setup successful?
 - Trigger to run during time passes:
   - Create object and tag with "Time Passes"
   - `timePasses()`

--- a/objects/0e627b/contained/fddf31/script.lua
+++ b/objects/0e627b/contained/fddf31/script.lua
@@ -5,6 +5,7 @@ function doSetup(params)
         return
     elseif color ~= Global.call("getSpiritColor", {name = "Fractured Days Split the Sky"}) then
         Player[color].broadcast("You have not picked Fractured Days Split the Sky!", Color.Red)
+        setupComplete = false
         return
     end
 

--- a/objects/0e627b/contained/fddf31/script.lua
+++ b/objects/0e627b/contained/fddf31/script.lua
@@ -2,11 +2,10 @@ function doSetup(params)
     local color = params.color
     if not Global.getVar("gameStarted") then
         Player[color].broadcast("Please wait for the game to start before pressing this button!", Color.Red)
-        return
+        return false
     elseif color ~= Global.call("getSpiritColor", {name = "Fractured Days Split the Sky"}) then
         Player[color].broadcast("You have not picked Fractured Days Split the Sky!", Color.Red)
-        setupComplete = false
-        return
+        return false
     end
 
     local position = Player[color].getHandTransform(2).position
@@ -56,4 +55,5 @@ function doSetup(params)
 
         self.destruct()
     end, 1)
+    return true
 end

--- a/objects/1a3d98/contained/241617/script.lua
+++ b/objects/1a3d98/contained/241617/script.lua
@@ -5,6 +5,7 @@ function doSetup(params)
         return
     elseif color ~= Global.call("getSpiritColor", {name = "Lightning's Swift Strike"}) then
         Player[color].broadcast("You have not picked Lightning's Swift Strike!", Color.Red)
+        setupComplete = false
         return
     end
 

--- a/objects/1a3d98/contained/241617/script.lua
+++ b/objects/1a3d98/contained/241617/script.lua
@@ -2,11 +2,10 @@ function doSetup(params)
     local color = params.color
     if not Global.getVar("gameStarted") then
         Player[color].broadcast("Please wait for the game to start before pressing this button!", Color.Red)
-        return
+        return false
     elseif color ~= Global.call("getSpiritColor", {name = "Lightning's Swift Strike"}) then
         Player[color].broadcast("You have not picked Lightning's Swift Strike!", Color.Red)
-        setupComplete = false
-        return
+        return false
     end
 
     local lightning = Global.call("getSpirit", {name = "Lightning's Swift Strike"})
@@ -19,4 +18,5 @@ function doSetup(params)
         lightning.script_state = JSON.encode(json)
         lightning.setTable("trackEnergy", json.trackEnergy)
     end
+    return true
 end

--- a/objects/SourceSpirit/script.lua
+++ b/objects/SourceSpirit/script.lua
@@ -438,8 +438,8 @@ function setupSpirit(obj, player_color)
 
             if Global.getVar("gameStarted") and ob.hasTag("Setup") and not ob.getVar("setupComplete") and not ob.hasTag("Aspect") then
                 Wait.frames(function()
-                    ob.setVar("setupComplete", true)
-                    ob.call("doSetup", {color=player_color})
+                    local success = ob.call("doSetup", {color=player_color})
+                    ob.setVar("setupComplete", success)
                 end, 1)
             end
         end
@@ -465,8 +465,8 @@ function setupSpirit(obj, player_color)
             if Global.getVar("gameStarted") and o.hasTag("Setup") and not o.getVar("setupComplete") and not o.hasTag("Aspect") then
                 local o = o  -- luacheck: ignore 423 (deliberate shadowing)
                 Wait.frames(function()
-                    o.setVar("setupComplete", true)
-                    o.call("doSetup", {color=player_color})
+                    local success = o.call("doSetup", {color=player_color})
+                    o.setVar("setupComplete", success)
                 end, 1)
             end
         end

--- a/objects/adffc0/contained/38188e/script.lua
+++ b/objects/adffc0/contained/38188e/script.lua
@@ -58,12 +58,13 @@ end
 
 function doSetup(params)
     if not Global.getVar("gameStarted") then
-        return
+        return false
     end
     self.UI.setAttribute("count", "text", healthCount)
     self.UI.setAttribute("players", "text", getNumPlayers())
     self.UI.setAttribute("drownPanel", "visibility", "")
     self.UI.setAttribute("drownPanel2", "visibility", "")
+    return true
 end
 
 function toggleExchange()

--- a/objects/efad15/contained/9ad187/script.lua
+++ b/objects/efad15/contained/9ad187/script.lua
@@ -37,6 +37,7 @@ function doSetup(params)
         return
     elseif color ~= Global.call("getSpiritColor", {name = spiritName}) then
         Player[color].broadcast("You have not picked " .. spiritName .. "!", Color.Red)
+        setupComplete = false
         return
     end
 

--- a/objects/efad15/contained/9ad187/script.lua
+++ b/objects/efad15/contained/9ad187/script.lua
@@ -34,11 +34,10 @@ function doSetup(params)
     local color = params.color
     if not Global.getVar("gameStarted") then
         Player[color].broadcast("Please wait for the game to start before pressing this button!", Color.Red)
-        return
+        return false
     elseif color ~= Global.call("getSpiritColor", {name = spiritName}) then
         Player[color].broadcast("You have not picked " .. spiritName .. "!", Color.Red)
-        setupComplete = false
-        return
+        return false
     end
 
     local serpent = Global.call("getSpirit", {name = spiritName})
@@ -59,6 +58,7 @@ function doSetup(params)
 
     updatePresence()
     Wait.time(updatePresence, 1, -1)
+    return true
 end
 
 local function presenceOnIsland(color)

--- a/objects/f33e62/contained/d440a5/script.lua
+++ b/objects/f33e62/contained/d440a5/script.lua
@@ -37,7 +37,7 @@ end
 
 function doSetup(params)
     if not Global.getVar("gameStarted") then
-        return
+        return false
     end
     self.UI.setAttribute("count", "text", count)
     self.UI.setAttribute("water", "text", 0)
@@ -55,6 +55,7 @@ function doSetup(params)
     })
 
     Wait.time(countWater, 2, -1)
+    return true
 end
 function timePasses()
     count = 0

--- a/objects/f9ea89/contained/bec5da/script.lua
+++ b/objects/f9ea89/contained/bec5da/script.lua
@@ -12,6 +12,7 @@ function doSetup(params)
         return
     elseif color ~= Global.call("getSpiritColor", {name = "River Surges in Sunlight"}) then
         Player[color].broadcast("You have not picked River Surges in Sunlight!", Color.Red)
+        setupComplete = false
         return
     end
 

--- a/objects/f9ea89/contained/bec5da/script.lua
+++ b/objects/f9ea89/contained/bec5da/script.lua
@@ -9,11 +9,10 @@ function doSetup(params)
     local color = params.color
     if not Global.getVar("gameStarted") then
         Player[color].broadcast("Please wait for the game to start before pressing this button!", Color.Red)
-        return
+        return false
     elseif color ~= Global.call("getSpiritColor", {name = "River Surges in Sunlight"}) then
         Player[color].broadcast("You have not picked River Surges in Sunlight!", Color.Red)
-        setupComplete = false
-        return
+        return false
     end
 
     for _, card in pairs(Player[color].getHandObjects(1)) do
@@ -23,4 +22,5 @@ function doSetup(params)
             break
         end
     end
+    return true
 end

--- a/script.lua
+++ b/script.lua
@@ -452,8 +452,8 @@ function onObjectEnterScriptingZone(zone, obj)
     elseif gameStarted and obj.hasTag("Setup") and not obj.getVar("setupComplete") then
         for color,data in pairs(selectedColors) do
             if data.zone == zone then
-                obj.setVar("setupComplete", true)
-                obj.call("doSetup", {color=color})
+                local success = obj.call("doSetup", {color=color})
+                obj.setVar("setupComplete", success)
                 break
             end
         end
@@ -3762,8 +3762,8 @@ function runSpiritSetup()
         if data.zone then
             for _,obj in pairs(data.zone.getObjects()) do
                 if obj.hasTag("Setup") and not obj.getVar("setupComplete") then
-                    obj.setVar("setupComplete", true)
-                    obj.call("doSetup", {color=color})
+                    local success = obj.call("doSetup", {color=color})
+                    obj.setVar("setupComplete", success)
                 end
             end
         end


### PR DESCRIPTION
Namely, Days That Never Were, Deep Slumber, Sunshine, and Immense. If the object was moved to the wrong spirit's play area first, it would broadcast the message that it was the wrong spirit, but the object would still have its setupComplete variable marked as true. as such, explicitly set setupComplete to false if setup fails due to being in the wrong spirit's area.