### PR TITLE
Add a variant option to randomly permute the thematic boards used.

### DIFF
--- a/objects/SetupChecker/script-state.json
+++ b/objects/SetupChecker/script-state.json
@@ -219,6 +219,7 @@
     "natureIncarnateSetup": true,
     "soloBlight": true,
     "thematicRebellion": false,
-    "thematicRedo": false
+    "thematicRedo": false,
+    "thematicPermute": false
   }
 }

--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -59,6 +59,7 @@ optionalBoardPairings = true
 optionalThematicRebellion = false
 optionalUniqueRebellion = false
 optionalThematicRedo = false
+optionalThematicPermute = false
 optionalGameResults = true
 optionalScaleBoard = true -- not currently hooked up into UI
 optionalDrowningCap = false -- not currently hooked up into UI
@@ -115,6 +116,7 @@ function onSave()
     data_table.variant.thematicRebellion = optionalThematicRebellion
     data_table.variant.uniqueRebellion = optionalUniqueRebellion
     data_table.variant.thematicRedo = optionalThematicRedo
+    data_table.variant.thematicPermute = optionalThematicPermute
     data_table.variant.gameResults = optionalGameResults
     data_table.variant.drowningCap = optionalDrowningCap
 
@@ -196,6 +198,7 @@ function onLoad(saved_data)
         optionalThematicRebellion = loaded_data.variant.thematicRebellion
         optionalUniqueRebellion = loaded_data.variant.uniqueRebellion
         optionalThematicRedo = loaded_data.variant.thematicRedo
+        optionalThematicPermute = loaded_data.variant.thematicPermute
         optionalGameResults = loaded_data.variant.gameResults
         optionalDrowningCap = loaded_data.variant.drowningCap
 
@@ -274,6 +277,7 @@ function onLoad(saved_data)
             self.UI.setAttribute("boardPairings", "isOn", optionalBoardPairings)
             self.UI.setAttribute("slaveRebellionBack", "isOn", optionalUniqueRebellion)
             self.UI.setAttribute("thematicRedo", "isOn", optionalThematicRedo)
+            self.UI.setAttribute("thematicPermute", "isOn", optionalThematicPermute)
             self.UI.setAttribute("carpetRedo", "isOn", Global.getVar("seaTile").getStateId() == 1)
             self.UI.setAttribute("gameResults", "isOn", optionalGameResults)
 
@@ -1262,6 +1266,9 @@ function loadConfig(config)
         if config.variant.thematicRedo ~= nil then
             optionalThematicRedo = config.variant.thematicRedo
         end
+        if config.variant.thematicPermute ~= nil then
+            optionalThematicPermute = config.variant.thematicPermute
+        end
         if config.variant.carpetRedo ~= nil then
             local seaTile = Global.getVar("seaTile")
             if config.variant.carpetRedo then
@@ -2225,6 +2232,10 @@ end
 function toggleThematicRedo()
     optionalThematicRedo = not optionalThematicRedo
     self.UI.setAttribute("thematicRedo", "isOn", optionalThematicRedo)
+end
+function toggleThematicPermute()
+    optionalThematicPermute = not optionalThematicPermute
+    self.UI.setAttribute("thematicPermute", "isOn", optionalThematicPermute)
 end
 function toggleCarpetRedo()
     local seaTile = Global.getVar("seaTile")

--- a/objects/SetupChecker/ui.xml
+++ b/objects/SetupChecker/ui.xml
@@ -216,6 +216,9 @@
                 <Cell columnSpan="2"><Toggle id="thematicRedo" onValueChanged="toggleThematicRedo" tooltip="An alternate appeareance for the Thematic boards,&#xA;so the terrains look like the Balanced boards">Use Recolored Thematic Island Boards</Toggle></Cell>
             </Row>
             <Row class="toggle">
+                <Cell columnSpan="2"><Toggle id="thematicPermute" onValueChanged="toggleThematicPermute" tooltip="Use a random contiguous subset of the thematic boards,&#xA;rather than the recommended set">Randomise Thematic Island Boards</Toggle></Cell>
+            </Row>
+            <Row class="toggle">
                 <Cell columnSpan="2"><Toggle id="carpetRedo" isOn="true" onValueChanged="toggleCarpetRedo" tooltip="An alternate appeareance for the ocean tile">Use Thematic Ocean Playmat</Toggle></Cell>
             </Row>
             <Row class="toggle">

--- a/objects/e924fe/script.lua
+++ b/objects/e924fe/script.lua
@@ -306,6 +306,7 @@ function ExportConfig()
     data.variant.thematicRebellion = SetupChecker.getVar("optionalThematicRebellion")
     data.variant.uniqueRebellion = SetupChecker.getVar("optionalUniqueRebellion")
     data.variant.thematicRedo = SetupChecker.getVar("optionalThematicRedo")
+    data.variant.thematicPermute = SetupChecker.getVar("optionalThematicPermute")
     data.variant.carpetRedo = Global.getVar("seaTile").getStateId() == 1
     data.variant.gameResults = SetupChecker.getVar("optionalGameResults")
 

--- a/script.lua
+++ b/script.lua
@@ -3266,7 +3266,7 @@ function BoardSetup()
     if #maps == 0 then
         if isThematic() then
             if SetupChecker.getVar("optionalThematicPermute") then
-                MapPlacen(getPermutedThematicLayout(numBoards))
+                MapPlacen(getPermutedThematicLayout())
             else
                 MapPlacen(boardLayouts[numBoards][boardLayout])
             end
@@ -4351,9 +4351,9 @@ thematicPermutations = { -- All possible combinations are listed, with non-conti
     },
 }
 ----
-function getPermutedThematicLayout(n)
+function getPermutedThematicLayout()
     -- Select a random permutation of the appropriate length.
-    local permutation = thematicPermutations[n][math.random(#thematicPermutations[n])]
+    local permutation = thematicPermutations[numBoards][math.random(#thematicPermutations[numBoards])]
     -- Subset the six-player thematic map with the appropriate permutation.
     local template = boardLayouts[6]["Thematic"]
     local boards = {}

--- a/script.lua
+++ b/script.lua
@@ -3265,7 +3265,11 @@ function BoardSetup()
     local maps = getMapTiles()
     if #maps == 0 then
         if isThematic() then
-            MapPlacen(boardLayouts[numBoards][boardLayout])
+            if SetupChecker.getVar("optionalThematicPermute") then
+                MapPlacen(getPermutedThematicLayout(numBoards))
+            else
+                MapPlacen(boardLayouts[numBoards][boardLayout])
+            end
         else
             StandardMapBag.shuffle()
             ExtraMapBag.shuffle()
@@ -4269,6 +4273,99 @@ themGuids = {
     ["SW"] = "0f2e60",
     ["SE"] = "505d5d",
 }
+thematicPermutations = { -- All possible combinations are listed, with non-contiguous ones commented out.
+    { -- 1 Board
+        {"NW"},
+        {"NE"},
+        {"W"},
+        {"E"},
+        {"SW"},
+        {"SE"},
+    },
+    { -- 2 Board
+        {"NW", "NE"},
+        {"NW", "W"},
+        --{"NW", "E"},
+        --{"NW", "SW"},
+        --{"NW", "SE"},
+        --{"NE", "W"},
+        {"NE", "E"},
+        --{"NE", "SW"},
+        --{"NE", "SE"},
+        {"W", "E"},
+        {"W", "SW"},
+        --{"W", "SE"},
+        --{"E", "SW"},
+        {"E", "SE"},
+        {"SW", "SE"},
+    },
+    { -- 3 Board
+        {"NW", "NE", "W"},
+        {"NW", "NE", "E"},
+        --{"NW", "NE", "SW"},
+        --{"NW", "NE", "SE"},
+        {"NW", "W", "E"},
+        {"NW", "W", "SW"},
+        --{"NW", "W", "SE"},
+        --{"NW", "E", "SW"},
+        --{"NW", "E", "SE"},
+        --{"NW", "SW", "SE"},
+        {"NE", "W", "E"},
+        --{"NE", "W", "SW"},
+        --{"NE", "W", "SE"},
+        --{"NE", "E", "SW"},
+        {"NE", "E", "SE"},
+        --{"NE", "SW", "SE"},
+        {"W", "E", "SW"},
+        {"W", "E", "SE"},
+        {"W", "SW", "SE"},
+        {"E", "SW", "SE"},
+    },
+    { -- 4 Board
+        {"NW", "NE", "W", "E"},
+        {"NW", "NE", "W", "SW"},
+        --{"NW", "NE", "W", "SE"},
+        --{"NW", "NE", "E", "SW"},
+        {"NW", "NE", "E", "SE"},
+        --{"NW", "NE", "SW", "SE"},
+        {"NW", "W", "E", "SW"},
+        {"NW", "W", "E", "SE"},
+        {"NW", "W", "SW", "SE"},
+        --{"NW", "E", "SW", "SE"},
+        {"NE", "W", "E", "SW"},
+        {"NE", "W", "E", "SE"},
+        --{"NE", "W", "SW", "SE"},
+        {"NE", "E", "SW", "SE"},
+        {"W", "E", "SW", "SE"},
+    },
+    { -- 5 Board
+        {"NW", "NE", "W", "E", "SW"},
+        {"NW", "NE", "W", "E", "SE"},
+        {"NW", "NE", "W", "SW", "SE"},
+        {"NW", "NE", "E", "SW", "SE"},
+        {"NW", "W", "E", "SW", "SE"},
+        {"NE", "W", "E", "SW", "SE"},
+    },
+    { -- 6 Board
+        {"NW", "NE", "W", "E", "SW", "SE"},
+    },
+}
+----
+function getPermutedThematicLayout(n)
+    -- Select a random permutation of the appropriate length.
+    local permutation = thematicPermutations[n][math.random(#thematicPermutations[n])]
+    -- Subset the six-player thematic map with the appropriate permutation.
+    local template = boardLayouts[6]["Thematic"]
+    local boards = {}
+    for _,boardName in pairs(permutation) do
+        for _,boardData in pairs(template) do
+            if boardData.board == boardName then
+                table.insert(boards, boardData)
+            end
+        end
+    end
+    return boards
+end
 ----
 function PopulateSpawnPositions()
     local boards = getMapTiles()

--- a/script.lua
+++ b/script.lua
@@ -4361,6 +4361,7 @@ function getPermutedThematicLayout(n)
         for _,boardData in pairs(template) do
             if boardData.board == boardName then
                 table.insert(boards, boardData)
+                break
             end
         end
     end


### PR DESCRIPTION
Some people on the Discord asked for this, and iakona indicated he might be interested in adding it at some point, so I coded it up. Two things to note:
- I've hard-coded all the possible layouts for each player count. It doesn't suffice to simply select a random set of boards, as that may give non-contiguous islands (and the oceans aren't lined up properly for archipelago). A "proper" solution to ensuring the set of boards remain contiguous would still need a hard-coded network of adjacencies, and then would need to do some sort of algorithm to ensure the set was contiguous (e.g. flood fill to determine whether it's contiguous and reroll if not, or something else to build a continuous set). That'd be a fair bit of extra code to maintain, and the set of possibilities was small enough to hard-code anyway, so I did that. I've done it in a very systematic way, at least, so it should be easy to check my work.
- I've done it by subsetting the six-player thematic board (so that the hard-coded part mentioned above only needs board names, not positions). This does mean that when it sets up a one-player board, say, it sets it up in a weird place: in the same place it would rest within a six player layout, rather than in the normal place for a true solo board. Up to you whether this is a problem or not: I can work on a solution if you do consider this a problem.