### PR TITLE
Fix a bug where objects' doSetup() functions could be called again after save/reload.

### DIFF
--- a/objects/adffc0/contained/38188e/script.lua
+++ b/objects/adffc0/contained/38188e/script.lua
@@ -2,10 +2,13 @@ local healthCount = 0
 local autoExchange = true
 
 function onSave()
-    local data_table = {
-        healthCount = healthCount,
-        autoExchange = autoExchange
-    }
+    -- We must build on the existing script state, to avoid overwriting setupComplete
+    local data_table = {}
+    if self.script_state ~= "" then
+        data_table = JSON.decode(self.script_state)
+    end
+    data_table.healthCount = healthCount
+    data_table.autoExchange = autoExchange
     return JSON.encode(data_table)
 end
 function onLoad(save_state)
@@ -15,7 +18,6 @@ function onLoad(save_state)
             healthCount = loaded_data.healthCount
             autoExchange = loaded_data.autoExchange
         end
-        setupComplete = true -- luacheck: ignore 111
         if autoExchange then
             exchangeAuto()
         end

--- a/objects/efad15/contained/9ad187/script.lua
+++ b/objects/efad15/contained/9ad187/script.lua
@@ -1,5 +1,4 @@
 local spiritName = "Serpent Slumbering Beneath the Island"
-local initialized = false
 
 local slumberTrack = {[0] = 5, 7, 8, 10, 11, 12, 13}
 local slumberPoints = {
@@ -12,22 +11,18 @@ local slumberPoints = {
 }
 
 function onLoad(saved_data)
+    local setupComplete = false
+    -- NB: setupComplete in the script state is set by the global script
     if saved_data ~= "" then
         local loaded_data = JSON.decode(saved_data)
-        initialized = loaded_data.initialized
+        setupComplete = loaded_data.setupComplete
     end
 
-    if initialized then
+    if setupComplete then
         self.interactable = false
         updatePresence()
         Wait.time(updatePresence, 1, -1)
     end
-end
-
-function onSave()
-    return JSON.encode{
-        initialized = initialized,
-    }
 end
 
 function doSetup(params)
@@ -48,7 +43,6 @@ function doSetup(params)
     end
     serpent.setSnapPoints(snapPoints)
 
-    initialized = true
     self.clearButtons()
     self.locked = true
     self.interactable = false

--- a/objects/f33e62/contained/d440a5/script.lua
+++ b/objects/f33e62/contained/d440a5/script.lua
@@ -1,9 +1,12 @@
 local count = 0
 
 function onSave()
-    local data_table = {
-        count = count
-    }
+    -- We must build on the existing script state, to avoid overwriting setupComplete
+    local data_table = {}
+    if self.script_state ~= "" then
+        data_table = JSON.decode(self.script_state)
+    end
+    data_table.count = count
     return JSON.encode(data_table)
 end
 function onLoad(save_state)
@@ -12,7 +15,6 @@ function onLoad(save_state)
             local loaded_data = JSON.decode(save_state)
             count = loaded_data.count
         end
-        setupComplete = true -- luacheck: ignore 111
 
         Wait.frames(function()
             self.UI.setAttribute("count", "text", count)

--- a/script.lua
+++ b/script.lua
@@ -453,10 +453,10 @@ function onObjectEnterScriptingZone(zone, obj)
     elseif gameStarted and obj.hasTag("Setup") then
         -- Whether the object has already done setup is stored in its script state, to persist across save/reload
         local json = JSON.decode(obj.script_state)
-        if not json or not json.setupComplete then
-            if not json then
-                json = {}
-            end
+        if not json then
+            json = {}
+        end
+        if not json.setupComplete then
             for color,data in pairs(selectedColors) do
                 if data.zone == zone then
                     local success = obj.call("doSetup", {color=color})
@@ -3650,10 +3650,10 @@ function runSpiritSetup()
                 if obj.hasTag("Setup") then
                     -- Whether the object has already done setup is stored in its script state, to persist across save/reload
                     local json = JSON.decode(obj.script_state)
-                    if not json or not json.setupComplete then
-                        if not json then
-                            json = {}
-                        end
+                    if not json then
+                        json = {}
+                    end
+                    if not json.setupComplete then
                         local success = obj.call("doSetup", {color=color})
                         json.setupComplete = success
                         obj.script_state = JSON.encode(json)

--- a/script.lua
+++ b/script.lua
@@ -3657,7 +3657,6 @@ function runSpiritSetup()
                         local success = obj.call("doSetup", {color=color})
                         json.setupComplete = success
                         obj.script_state = JSON.encode(json)
-                        break
                     end
                 end
             end


### PR DESCRIPTION
Fix #113.
This could occur if the objects were picked up a moved within the player area. This was because the setupComplete variable was stored in a way that did not persist across save/reload. Store it in script state instead to fix that. This also require slight changes to Deep Slumber, Pour Down Power Across the Island, and Ocean's Drowning bag, to prevent their onSave() functions overwriting the script state.