### PR TITLE
Have Scotland's InvaderDeckSetup() respect special stage 2 cards.

### DIFF
--- a/objects/37a592/script.lua
+++ b/objects/37a592/script.lua
@@ -28,9 +28,10 @@ end
 
 function InvaderDeckSetup(params)
     if params.level >= 2 then
+        local invaderCards = Global.getTable("invaderCards")
         local stageIICount = 0
         for i=1,#params.deck do
-            if params.deck[i] == 2 then
+            if params.deck[i] == 2 or (invaderCards[params.deck[i]] and invaderCards[params.deck[i]].stage == 2) then
                 stageIICount = stageIICount + 1
                 if stageIICount == 3 then
                     params.deck[i] = "C"


### PR DESCRIPTION
Currently, Russia and Prussia's invader deck setup treat specially placed stage 2 cards (e.g. "C") as stage two cards, but Scotland's doesn't. As Scotland is currently the only specially placed stage two card, it never has to deal with itself, so it's okay. But with HME coming, this will be necessary.