### PR TITLE
Fix bugs around updating the SetupChecker UI.

### DIFF
--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -455,6 +455,7 @@ end
 function addExpansion(bag)
     expansions[bag.getName()] = bag.guid
     updateSelfXml()
+    Wait.frames(function() toggleExpansion(_, _, bag.getName()) end, 1)
 end
 function addAdversary(obj)
     if adversaries[obj.getName()] == nil then

--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -442,7 +442,8 @@ function newAdversaryScenario(obj, adversary, disabled)
         }
     }, {})
 end
-function expansionHasEvents(bag)
+function expansionHasEvents(bagGUID)
+    local bag = getObjectFromGUID(bagGUID)
     local hasEvents = false
     for _,obj in pairs(bag.getObjects()) do
         if obj.name == "Events" then
@@ -890,7 +891,7 @@ function toggleExpansion(_, _, id)
     Global.setTable("expansions", exps)
     self.UI.setAttribute(id, "isOn", bool)
 
-    if expansionHasEvents(getObjectFromGUID(expansions[id])) then
+    if expansionHasEvents(expansions[id]) then
         local events = Global.getTable("events")
         events[id] = exps[id]
         Global.setTable("events", events)
@@ -932,7 +933,7 @@ function toggleAllEvents()
         local exps = Global.getTable("expansions")
         for exp,enabled in pairs(exps) do
             if enabled then
-                if expansionHasEvents(getObjectFromGUID(expansions[exp])) then
+                if expansionHasEvents(expansions[exp]) then
                     events[exp] = true
                     toggleEvents(nil, nil, exp.." Events")
                 end
@@ -2467,7 +2468,7 @@ function updateEventToggles()
     local events = Global.getTable("events")
     local values = {}
     for name,guid in pairs(expansions) do
-        if expansionHasEvents(getObjectFromGUID(guid)) then
+        if expansionHasEvents(guid) then
             -- The Global events table stores nil for disabled expansions
             -- We want a boolean false, so we explicitly check for equality to true
             values[name.." Events"] = (events[name] == true)

--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -338,7 +338,7 @@ function onLoad(saved_data)
                     updateScenarioList(),
                     updateExpansionToggles(),
                     updateEventToggles(),
-                    updateBoardLayouts(numPlayers),
+                    updateBoardLayouts(),
                     updatePlaytestExpansionList(),
                 }
                 updateXml(self, funcList)
@@ -653,13 +653,13 @@ function updateNumPlayers(value, updateUI)
         if updateLayoutsID ~= 0 then
             Wait.stop(updateLayoutsID)
         end
-        updateLayoutsID = Wait.time(function() updateXml(self, {updateBoardLayouts(numPlayers)}) end, 0.5)
+        updateLayoutsID = Wait.time(function() updateXml(self, {updateBoardLayouts()}) end, 0.5)
     end
 end
-function updateBoardLayouts(numPlayers)
-    local numBoards = numPlayers
+function updateBoardLayouts()
+    local numBoards = Global.getVar("numPlayers")
     if optionalExtraBoard then
-        numBoards = numPlayers + 1
+        numBoards = numBoards + 1
     end
     local layoutNames = { "Balanced" }
     local alternateBoardLayoutNames = Global.getVar("alternateBoardLayoutNames")
@@ -668,7 +668,7 @@ function updateBoardLayouts(numPlayers)
             table.insert(layoutNames, layout)
         end
     end
-    local canThematic = numPlayers < 6 or (numPlayers == 6 and not optionalExtraBoard)
+    local canThematic = (numBoards <= 6)
     if canThematic then
         table.insert(layoutNames, "Thematic")
     end
@@ -2183,7 +2183,7 @@ function toggleExtraBoard()
         if updateLayoutsID ~= 0 then
             Wait.stop(updateLayoutsID)
         end
-        updateLayoutsID = Wait.time(function() updateXml(self, {updateBoardLayouts(numPlayers)}) end, 0.5)
+        updateLayoutsID = Wait.time(function() updateXml(self, {updateBoardLayouts()}) end, 0.5)
     end
 end
 function toggleBoardPairings()

--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -444,6 +444,9 @@ function newAdversaryScenario(obj, adversary, disabled)
 end
 function expansionHasEvents(bagGUID)
     local bag = getObjectFromGUID(bagGUID)
+    if bag == nil then
+        return false
+    end
     local hasEvents = false
     for _,obj in pairs(bag.getObjects()) do
         if obj.name == "Events" then

--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -339,7 +339,7 @@ function onLoad(saved_data)
                     updateExpansionToggles(),
                     updateEventToggles(),
                     updateBoardLayouts(numPlayers),
-                    updatePlaytestExpansionList(expansions),
+                    updatePlaytestExpansionList(),
                 }
                 updateXml(self, funcList)
                 Wait.frames(function()
@@ -523,7 +523,7 @@ function removeExpansion(bag)
     local funcList = {
         updateExpansionToggles(),
         updateEventToggles(),
-        updatePlaytestExpansionList(exps),
+        updatePlaytestExpansionList(),
     }
     updateXml(self, funcList)
 
@@ -913,7 +913,7 @@ function toggleExpansion(_, _, id)
     end
     updateDifficulty()
 
-    Wait.frames(function() updateXml(self, {updatePlaytestExpansionList(exps)}) end, 1)
+    Wait.frames(function() updateXml(self, {updatePlaytestExpansionList()}) end, 1)
     Wait.frames(updateRequiredContent, 2)
 end
 function toggleAllEvents()
@@ -972,10 +972,10 @@ function toggleEvents(_, _, id)
     self.UI.setAttribute(id, "isOn", bool)
 end
 
-function updatePlaytestExpansionList(exps)
+function updatePlaytestExpansionList()
     local playtestExpansions = {"None"}
     local found = false
-    for name,enabled in pairs(exps) do
+    for name,enabled in pairs(Global.getTable("expansions")) do
         if enabled then
             table.insert(playtestExpansions, name)
             if playtestExpansion == name then

--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -331,17 +331,8 @@ function onLoad(saved_data)
                 newAdversaryScenario(getObjectFromGUID(guid), false, scenarios[name] == nil)
             end
 
-            -- queue up all dropdown changes at once
             Wait.frames(function()
-                local funcList = {
-                    updateAdversaryList(),
-                    updateScenarioList(),
-                    updateExpansionToggles(),
-                    updateEventToggles(),
-                    updateBoardLayouts(),
-                    updatePlaytestExpansionList(),
-                }
-                updateXml(self, funcList)
+                updateSelfXml()
                 Wait.frames(function()
                     toggleSimpleMode()
                     toggleChallenge()
@@ -382,6 +373,18 @@ function onObjectSpawn(obj)
             addExpansion(obj)
         end
     end
+end
+function updateSelfXml()
+    -- Bundles all updates to own UI XML together, to prevent race conditions.
+    local funcList = {
+        updateAdversaryList(),
+        updateScenarioList(),
+        updateExpansionToggles(),
+        updateEventToggles(),
+        updateBoardLayouts(),
+        updatePlaytestExpansionList(),
+    }
+    updateXml(self, funcList)
 end
 function toggleAdversary(_, value, adversary)
     local obj = getObjectFromGUID(allAdversaries[adversary])
@@ -451,7 +454,7 @@ function expansionHasEvents(bag)
 end
 function addExpansion(bag)
     expansions[bag.getName()] = bag.guid
-    updateXml(self, {updateExpansionToggles(), updateEventToggles()})
+    updateSelfXml()
 end
 function addAdversary(obj)
     if adversaries[obj.getName()] == nil then
@@ -460,7 +463,7 @@ function addAdversary(obj)
         return
     end
     adversaries[obj.getName()] = obj.guid
-    Wait.frames(function() updateXml(self, {updateAdversaryList()}) end, 1)
+    Wait.frames(updateSelfXml, 1)
 end
 function addScenario(obj)
     if scenarios[obj.getName()] == nil then
@@ -469,7 +472,7 @@ function addScenario(obj)
         return
     end
     scenarios[obj.getName()] = obj.guid
-    Wait.frames(function() updateXml(self, {updateScenarioList()}) end, 1)
+    Wait.frames(updateSelfXml, 1)
 end
 function onDestroy()
     exit = true
@@ -520,12 +523,7 @@ function removeExpansion(bag)
     events[bag.getName()] = nil
     Global.setTable("events", events)
 
-    local funcList = {
-        updateExpansionToggles(),
-        updateEventToggles(),
-        updatePlaytestExpansionList(),
-    }
-    updateXml(self, funcList)
+    updateSelfXml()
 
     Wait.frames(updateRequiredContent, 1)
 end
@@ -542,7 +540,7 @@ function removeAdversary(obj)
                 Global.setVar("adversaryCard2", nil)
                 toggleSupportingLevel(nil, 0)
             end
-            Wait.frames(function() updateXml(self, {updateAdversaryList()}) end, 1)
+            Wait.frames(updateSelfXml, 1)
             break
         end
     end
@@ -583,7 +581,7 @@ function removeScenario(obj)
                 Global.setVar("scenarioCard", nil)
                 updateDifficulty()
             end
-            Wait.frames(function() updateXml(self, {updateScenarioList()}) end, 1)
+            Wait.frames(updateSelfXml, 1)
             break
         end
     end
@@ -653,7 +651,7 @@ function updateNumPlayers(value, updateUI)
         if updateLayoutsID ~= 0 then
             Wait.stop(updateLayoutsID)
         end
-        updateLayoutsID = Wait.time(function() updateXml(self, {updateBoardLayouts()}) end, 0.5)
+        updateLayoutsID = Wait.time(updateSelfXml, 0.5)
     end
 end
 function updateBoardLayouts()
@@ -913,7 +911,7 @@ function toggleExpansion(_, _, id)
     end
     updateDifficulty()
 
-    Wait.frames(function() updateXml(self, {updatePlaytestExpansionList()}) end, 1)
+    Wait.frames(updateSelfXml, 1)
     Wait.frames(updateRequiredContent, 2)
 end
 function toggleAllEvents()
@@ -2183,7 +2181,7 @@ function toggleExtraBoard()
         if updateLayoutsID ~= 0 then
             Wait.stop(updateLayoutsID)
         end
-        updateLayoutsID = Wait.time(function() updateXml(self, {updateBoardLayouts()}) end, 0.5)
+        updateLayoutsID = Wait.time(updateSelfXml, 0.5)
     end
 end
 function toggleBoardPairings()

--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -530,10 +530,15 @@ function onObjectDestroy(obj)
     end
 end
 function removeExpansion(bag)
+    expansions[bag.getName()] = nil
+
     local exps = Global.getTable("expansions")
     exps[bag.getName()] = nil
     Global.setTable("expansions", exps)
-    expansions[bag.getName()] = nil
+
+    local events = Global.getTable("events")
+    events[bag.getName()] = nil
+    Global.setTable("events", events)
 
     local funcList = {
         removeToggle("expansionsRow", bag.getName()),

--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -538,10 +538,8 @@ function removeExpansion(bag)
     local funcList = {
         removeToggle("expansionsRow", bag.getName()),
         removeToggle("events", bag.getName().." Events"),
+        updatePlaytestExpansionList(exps),
     }
-    if playtestExpansion == bag.getName() then
-        table.insert(funcList, updatePlaytestExpansionList(exps))
-    end
     updateXml(self, funcList)
 
     Wait.frames(updateRequiredContent, 1)

--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -455,7 +455,7 @@ end
 function addExpansion(bag)
     expansions[bag.getName()] = bag.guid
     updateSelfXml()
-    Wait.frames(function() toggleExpansion(_, _, bag.getName()) end, 1)
+    Wait.frames(function() toggleExpansion(nil, nil, bag.getName()) end, 1)
 end
 function addAdversary(obj)
     if adversaries[obj.getName()] == nil then

--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -340,15 +340,8 @@ function onLoad(saved_data)
                     updatePlaytestExpansionList(expansions),
                 }
                 for expansion,guid in pairs(expansions) do
-                    local hasEvents = false
-                    for _,obj in pairs(getObjectFromGUID(guid).getObjects()) do
-                        if obj.name == "Events" then
-                            hasEvents = true
-                            break
-                        end
-                    end
                     table.insert(funcList, addExpansionToggle(expansion))
-                    if hasEvents then
+                    if expansionHasEvents(getObjectFromGUID(guid)) then
                         table.insert(funcList, addEventToggle(expansion))
                     end
                 end
@@ -460,7 +453,7 @@ function newAdversaryScenario(obj, adversary, disabled)
         }
     }, {})
 end
-function addExpansion(bag)
+function expansionHasEvents(bag)
     local hasEvents = false
     for _,obj in pairs(bag.getObjects()) do
         if obj.name == "Events" then
@@ -468,9 +461,12 @@ function addExpansion(bag)
             break
         end
     end
+    return hasEvents
+end
+function addExpansion(bag)
     if not expansions[bag.getName()] then
         local funcList = {addExpansionToggle(bag.getName())}
-        if hasEvents then
+        if expansionHasEvents(bag) then
             table.insert(funcList, addEventToggle(bag.getName()))
         end
         updateXml(self, funcList)
@@ -912,15 +908,7 @@ function toggleExpansion(_, _, id)
     Global.setTable("expansions", exps)
     self.UI.setAttribute(id, "isOn", bool)
 
-    local hasEvents = false
-    for _,obj in pairs(getObjectFromGUID(expansions[id]).getObjects()) do
-        if obj.name == "Events" then
-            hasEvents = true
-            break
-        end
-    end
-
-    if hasEvents then
+    if expansionHasEvents(getObjectFromGUID(expansions[id])) then
         local events = Global.getTable("events")
         events[id] = exps[id]
         Global.setTable("events", events)
@@ -962,14 +950,7 @@ function toggleAllEvents()
         local exps = Global.getTable("expansions")
         for exp,enabled in pairs(exps) do
             if enabled then
-                local hasEvents = false
-                for _,obj in pairs(getObjectFromGUID(expansions[exp]).getObjects()) do
-                    if obj.name == "Events" then
-                        hasEvents = true
-                        break
-                    end
-                end
-                if hasEvents then
+                if expansionHasEvents(getObjectFromGUID(expansions[exp])) then
                     events[exp] = true
                     toggleEvents(nil, nil, exp.." Events")
                 end

--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -2459,7 +2459,7 @@ function addExpansionToggle(value)
             children={},
         })
         local count = #t.children[1].children[1].children
-        t.attributes["preferredHeight"] = math.floor((count + 1) / 2) * 60 + 0.1
+        t.attributes["preferredHeight"] = math.ceil(count / 2) * 60 + 0.1
     end)
 end
 function addEventToggle(value)
@@ -2471,7 +2471,7 @@ function addEventToggle(value)
             children={},
         })
         local count = #t.children[1].children[1].children
-        t.attributes["preferredHeight"] = math.floor((count + 1) / 2) * 60 + 0.1
+        t.attributes["preferredHeight"] = math.ceil(count / 2) * 60 + 0.1
     end)
 end
 function removeToggle(id, value)
@@ -2483,7 +2483,7 @@ function removeToggle(id, value)
             end
         end
         local count = #t.children[1].children[1].children
-        t.attributes["preferredHeight"] = math.floor((count + 1) / 2) * 60 + 0.1
+        t.attributes["preferredHeight"] = math.ceil(count / 2) * 60 + 0.1
     end)
 end
 


### PR DESCRIPTION
Primarily the race condition that would prevent all the relevant dropdowns getting updated if an adversary and a scenario were both loaded in simultaneously, but I fixed a few other bugs I noticed while I was at it.

Also make newly added expansions default to being enabled.