### PR TITLE
Add the Island Tile tag to allow non-board parts of the island.

### DIFF
--- a/objects/1ea4cf/script.lua
+++ b/objects/1ea4cf/script.lua
@@ -222,6 +222,7 @@ function checkLoss()
                             max_distance = 6,
                         })
                         for _,v in pairs(hits) do
+                            -- The use of isIslandBoard rather than isIsland here is intentional: the Endless Dark is not a land and thus cannot be a sacred site
                             if v.hit_object ~= obj and Global.call("isIslandBoard", {obj=v.hit_object}) then
                                 count = count + 1
                                 break

--- a/objects/efad15/contained/9ad187/script.lua
+++ b/objects/efad15/contained/9ad187/script.lua
@@ -80,7 +80,7 @@ local function presenceOnIsland(color)
                     })
                     for _, hit in pairs(hits) do
                         local obj = hit.hit_object
-                        if Global.call("isIslandBoard", {obj=obj}) then
+                        if Global.call("isIsland", {obj=obj}) then
                             local quantity = presence.getQuantity()
                             if quantity == -1 then
                                 count = count + 1

--- a/savegame.json
+++ b/savegame.json
@@ -190,6 +190,14 @@
         "normalized": "uninteractable"
       },
       {
+        "displayed": "Balanced",
+        "normalized": "balanced"
+      },
+      {
+        "displayed": "Thematic",
+        "normalized": "thematic"
+      },
+      {
         "displayed": "Invader Card",
         "normalized": "invader_card"
       },

--- a/savegame.json
+++ b/savegame.json
@@ -198,6 +198,10 @@
         "normalized": "thematic"
       },
       {
+        "displayed": "Island Tile",
+        "normalized": "island_tile"
+      },
+      {
         "displayed": "Invader Card",
         "normalized": "invader_card"
       },

--- a/script.lua
+++ b/script.lua
@@ -231,7 +231,7 @@ function onObjectCollisionEnter(hit_object, collision_info)
             end
         end
     -- TODO: extract cast down code once onObjectCollisionEnter can exist outside of global
-    elseif isIslandBoard({obj=hit_object}) and hit_object.guid == castDown then
+    elseif hit_object.guid == castDown then
         cleanupObject({obj = collision_info.collision_object, fear = true, remove = true, color = castDownColor, reason = "Cast Down"})
         if castDownTimer ~= nil then
             Wait.stop(castDownTimer)

--- a/script.lua
+++ b/script.lua
@@ -5140,7 +5140,7 @@ function checkPresenceLoss()
                         max_distance = 1,
                     })
                     for _,v in pairs(hits) do
-                        if v.hit_object ~= obj and isIslandBoard({obj=v.hit_object}) then
+                        if v.hit_object ~= obj and isIsland({obj=v.hit_object}) then
                             colors[color] = true
                             break
                         end
@@ -5545,7 +5545,7 @@ function upCastRay(obj,dist)
     })
     local hitObjects = {}
     for _,v in pairs(hits) do
-        if v.hit_object ~= obj and not isIslandBoard({obj=v.hit_object}) then
+        if v.hit_object ~= obj and not isIsland({obj=v.hit_object}) then
             table.insert(hitObjects,v.hit_object)
         end
     end
@@ -7617,6 +7617,13 @@ function isIslandBoard(params)
         return false
     end
     return params.obj.hasTag("Balanced") or params.obj.hasTag("Thematic")
+end
+function isIsland(params)
+    -- As isIslandBoard, except it also includes island tiles such as the Endless Dark
+    if params.obj == nil then
+        return false
+    end
+    return params.obj.hasTag("Balanced") or params.obj.hasTag("Thematic") or params.obj.hasTag("Island Tile")
 end
 function isPowerCard(params)
     if params.card == nil then

--- a/script.lua
+++ b/script.lua
@@ -7619,7 +7619,6 @@ function isIslandBoard(params)
     return params.obj.hasTag("Balanced") or params.obj.hasTag("Thematic")
 end
 function isIsland(params)
-    -- As isIslandBoard, except it also includes island tiles such as the Endless Dark
     if params.obj == nil then
         return false
     end

--- a/script.lua
+++ b/script.lua
@@ -7623,7 +7623,7 @@ function isIsland(params)
     if params.obj == nil then
         return false
     end
-    return params.obj.hasTag("Balanced") or params.obj.hasTag("Thematic") or params.obj.hasTag("Island Tile")
+    return isIslandBoard(params) or params.obj.hasTag("Island Tile")
 end
 function isPowerCard(params)
     if params.card == nil then


### PR DESCRIPTION
For example, the Endless Dark. This will ensure they interact correctly with the presence loss condition and Serpent's Deep Slumber.