### PR TITLE
Fix a bug with "Modify Cost" objects in spirit bags.

### DIFF
--- a/script.lua
+++ b/script.lua
@@ -5900,7 +5900,9 @@ function reclaimAll(target_obj, source_color)
 end
 function modifyCost(params)
     for _,object in pairs(getObjectsWithTag("Modify Cost")) do
-        params.costs = object.call("modifyCost", params)
+        if not object.spawning then
+            params.costs = object.call("modifyCost", params)
+        end
     end
     return params.costs
 end


### PR DESCRIPTION
Having an object tagged with "Modify Cost" in a spirit bag when selecting the spirit would cause an error, as it would call the modifyCost() function before the object was finished spawning. A simple check that the object has finished spawning before calling the function suffices to fix it.