### PR TITLE
Set the cost and elements on Nature's Connection.

### DIFF
--- a/objects/JEBag/contained/80b54a/contained/c578b2/script.lua
+++ b/objects/JEBag/contained/80b54a/contained/c578b2/script.lua
@@ -1,0 +1,2 @@
+elements="00000000"
+energy=0


### PR DESCRIPTION
They are all zero, but not setting them means it doesn't get the Blitz discount.