### PR TITLE
Make buttons on power/event/fear cards remove only themselves.

### DIFF
--- a/objects/84e8f2/contained/96f27d/contained/a27e7b/script.lua
+++ b/objects/84e8f2/contained/96f27d/contained/a27e7b/script.lua
@@ -12,5 +12,5 @@ function onLoad()
 end
 function noHeal(card)
     Global.setVar("noHealInvader", true)
-    card.clearButtons()
+    Global.call("removeButtons", {obj = card, click_function = "noHeal", function_owner = self})
 end

--- a/objects/BnCBag/contained/05f7b7/contained/40a9cb/script.lua
+++ b/objects/BnCBag/contained/05f7b7/contained/40a9cb/script.lua
@@ -13,5 +13,5 @@ function onLoad()
 end
 function returnFear(card)
     Global.getVar("aidBoard").call("fearCard", { earned = false })
-    self.clearButtons()
+    Global.call("removeButtons", {obj = card, click_function = "returnFear", function_owner = self})
 end

--- a/objects/BnCBag/contained/cfd4d1/object.json
+++ b/objects/BnCBag/contained/cfd4d1/object.json
@@ -106,7 +106,7 @@
           "Type": 0
         }
       },
-      "LuaScript": "function onLoad()\n    self.createButton({\n        click_function = \"returnFear\",\n        function_owner = self,\n        label          = \"Add Fear Card\",\n        position       = Vector(0,0.3,1.43),\n        width          = 1200,\n        scale          = Vector(0.65,1,0.65),\n        height         = 160,\n        font_size      = 150,\n        tooltip = \"Add Fear Card\"\n    })\nend\nfunction returnFear(card)\n    Global.call(\"addFearCard\", {})\n    self.clearButtons()\nend",
+      "LuaScript": "function onLoad()\n    self.createButton({\n        click_function = \"returnFear\",\n        function_owner = self,\n        label          = \"Add Fear Card\",\n        position       = Vector(0,0.3,1.43),\n        width          = 1200,\n        scale          = Vector(0.65,1,0.65),\n        height         = 160,\n        font_size      = 150,\n        tooltip = \"Add Fear Card\"\n    })\nend\nfunction returnFear(card)\n    Global.call(\"addFearCard\", {})\n    Global.call(\"removeButtons\", {obj = card, click_function = \"returnFear\", function_owner = self})\nend",
       "LuaScriptState": "",
       "XmlUI": ""
     }

--- a/objects/BnCBag/contained/cfd4d1/script.lua
+++ b/objects/BnCBag/contained/cfd4d1/script.lua
@@ -13,5 +13,5 @@ function onLoad()
 end
 function returnFear(card)
     Global.call("addFearCard", {})
-    self.clearButtons()
+    Global.call("removeButtons", {obj = card, click_function = "returnFear", function_owner = self})
 end

--- a/objects/JEBag/contained/299e38/contained/6d14c5/script.lua
+++ b/objects/JEBag/contained/299e38/contained/6d14c5/script.lua
@@ -16,5 +16,5 @@ function grabReminder(card)
         position = card.getPosition() + Vector(0, 1, 0),
         rotation = Vector(0, 180, 0)
     })
-    card.clearButtons()
+    Global.call("removeButtons", {obj = card, click_function = "grabReminder", function_owner = self})
 end

--- a/objects/JEBag/contained/299e38/contained/86c840/script.lua
+++ b/objects/JEBag/contained/299e38/contained/86c840/script.lua
@@ -48,5 +48,5 @@ function removeCards(card)
             end
         end
     end
-    card.clearButtons()
+    Global.call("removeButtons", {obj = card, click_function = "removeCards", function_owner = self})
 end

--- a/objects/JEBag/contained/299e38/contained/b7ac93/script.lua
+++ b/objects/JEBag/contained/299e38/contained/b7ac93/script.lua
@@ -12,5 +12,5 @@ function onLoad()
 end
 function noFear(card)
     Global.setVar("noFear", true)
-    card.clearButtons()
+    Global.call("removeButtons", {obj = card, click_function = "noFear", function_owner = self})
 end

--- a/objects/JEBag/contained/299e38/contained/c5a72e/script.lua
+++ b/objects/JEBag/contained/299e38/contained/c5a72e/script.lua
@@ -16,5 +16,5 @@ function grabReminder(card)
         position = card.getPosition() + Vector(0, 1, 0),
         rotation = Vector(0, 180, 0)
     })
-    card.clearButtons()
+    Global.call("removeButtons", {obj = card, click_function = "grabReminder", function_owner = self})
 end

--- a/objects/JEBag/contained/98a916/contained/bab312/script.lua
+++ b/objects/JEBag/contained/98a916/contained/bab312/script.lua
@@ -26,5 +26,5 @@ function grabReminder(card)
         position = card.getPosition() + Vector(0, 1, 0),
         rotation = Vector(0, 180, 0)
     })
-    card.clearButtons()
+    Global.call("removeButtons", {obj = card, click_function = "grabReminder", function_owner = self})
 end

--- a/objects/JEBag/contained/98a916/contained/d45b0d/script.lua
+++ b/objects/JEBag/contained/98a916/contained/d45b0d/script.lua
@@ -26,5 +26,5 @@ function grabReminder(card)
         position = card.getPosition() + Vector(0, 1, 0),
         rotation = Vector(0, 180, 0)
     })
-    card.clearButtons()
+    Global.call("removeButtons", {obj = card, click_function = "grabReminder", function_owner = self})
 end

--- a/script.lua
+++ b/script.lua
@@ -2273,6 +2273,28 @@ function isObjectInHand(obj)
     return false
 end
 
+function removeButtons(params)
+    -- "params" is a table containing "obj", plus any number of other parameters
+    -- Removes buttons on obj with parameters matching all the other parameters given in params
+    -- "label" and "click_function" are the most likely parameters to match by
+    local obj = params.obj
+    params.obj = nil
+
+    -- Iterate over buttons in reverse order, so that removals do not change indices
+    local buttons = obj.getButtons()
+    for i = #buttons,1,-1 do
+        local match = true
+        for key,val in pairs(params) do
+            if buttons[i][key] != val then
+                match = false
+            end
+        end
+        if match then
+            obj.removeButton(buttons[i].index)
+        end
+    end
+end
+
 function getPowerZoneObjects(handP)
     local hits = upCastPosSizRot(
         handOffset + handP, -- pos

--- a/script.lua
+++ b/script.lua
@@ -2287,6 +2287,7 @@ function removeButtons(params)
         for key,val in pairs(params) do
             if buttons[i][key] ~= val then
                 match = false
+                break
             end
         end
         if match then

--- a/script.lua
+++ b/script.lua
@@ -2285,7 +2285,7 @@ function removeButtons(params)
     for i = #buttons,1,-1 do
         local match = true
         for key,val in pairs(params) do
-            if buttons[i][key] != val then
+            if buttons[i][key] ~= val then
                 match = false
             end
         end


### PR DESCRIPTION
E.g. "Grab Reminder" or "Return Fear" buttons. They were wiping all buttons from the cards, with `clearButtons()`, which could interfere with some custom scripting.

To explain the rationale for this change, Lolzax is working on some scripting for impending cards that adds additional buttons to impending power cards (changing the amount of energy they were impended with, or designating them as targets for G3). But the "Grab Reminder" buttons on Dream of the Untouched Land and Bargains of Power and Protection wipe *all* buttons from the card when they're pressed, including any extra ones for impending.