### PR TITLE
Fix a variety of bugs when reshuffling decks on power gain.

### DIFF
--- a/script.lua
+++ b/script.lua
@@ -2116,6 +2116,16 @@ function DealPowerCards(player, cardCount, deckZone, discardZone, playtestDeckZo
     local cardsResting = 0
     local powerDealCentre = handOffset + handPos
 
+    local function countDeck(deck)
+        if deck == nil then
+            return 0
+        elseif deck.type == "Card" then
+            return 1
+        elseif deck.type == "Deck" then
+            return deck.getQuantity()
+        end
+        return 0
+    end
     local function dealPowerCards(deck, discard, deckPos, count, isPlaytest)
         if deck == nil then
         elseif deck.type == "Card" then
@@ -2168,6 +2178,15 @@ function DealPowerCards(player, cardCount, deckZone, discardZone, playtestDeckZo
             playtestCount = 3
         end
     end
+
+    -- If there are not enough playtest powers available, deal more non-playtest powers, or vice versa
+    if playtestPowers > 0 then
+        local availableCards = countDeck(deckObj) + countDeck(discardObj)
+        local availablePlaytestCards = countDeck(playtestDeckObj) + countDeck(playtestDiscardObj)
+        playtestCount = math.min(playtestCount, availablePlaytestCards)
+        playtestCount = math.max(playtestCount, cardCount - availableCards)
+    end
+
     dealPowerCards(deckObj, discardObj, deckZone.getPosition(), cardCount - playtestCount, false)
     dealPowerCards(playtestDeckObj, playtestDiscardObj, playtestDeckZone.getPosition(), playtestCount, true)
 

--- a/script.lua
+++ b/script.lua
@@ -2144,25 +2144,14 @@ function DealPowerCards(player, cardCount, deckZone, discardZone, playtestDeckZo
             end
         end
         if count > 0 then
-            deck = powersDiscardZone.getObjects()[1]
-            deck.setPositionSmooth(powersZone.getPosition(), false, true)
-            deck.setRotationSmooth(Vector(0, 180, 180), false, true)
-            deck.shuffle()
-            wt(0.5)
+            local discardDeck = powersDiscardZone.getObjects()[1]
+            if discardDeck ~= nil then
+                discardDeck.setPositionSmooth(powersZone.getPosition(), false, true)
+                discardDeck.setRotationSmooth(Vector(0, 180, 180), false, true)
+                discardDeck.shuffle()
+                wt(0.5)
 
-            for i=1, math.min(deck.getQuantity(), count) do
-                local tempCard = deck.takeObject({
-                    position = powerDealCentre + cardPlaceOffset[cardsAdded + 1],
-                    flip = true,
-                    callback_function = CreatePickPowerButton,
-                })
-                tempCard.setLock(true)
-                if isPlaytest then
-                    tempCard.addTag("Playtest")
-                end
-                cardsAdded = cardsAdded + 1
-                count = count - 1
-                Wait.condition(function() cardsResting = cardsResting + 1 end, function() return not tempCard.isSmoothMoving() end)
+                dealPowerCards(powersZone, powersDiscardZone, count, isPlaytest)
             end
         end
     end

--- a/script.lua
+++ b/script.lua
@@ -2115,7 +2115,7 @@ function DealPowerCards(player, cardCount, deckZone, discardZone, playtestDeckZo
         local deck = powersZone.getObjects()[1]
         if deck == nil then
         elseif deck.type == "Card" then
-            if cardsAdded < count then
+            if cardsAdded - offset < count then
                 deck.setLock(true)
                 deck.setPositionSmooth(powerDealCentre + cardPlaceOffset[offset + 1])
                 deck.setRotationSmooth(Vector(0, 180, 0))
@@ -2141,14 +2141,14 @@ function DealPowerCards(player, cardCount, deckZone, discardZone, playtestDeckZo
                 Wait.condition(function() cardsResting = cardsResting + 1 end, function() return not tempCard.isSmoothMoving() end)
             end
         end
-        if cardsAdded < count then
+        if cardsAdded - offset < count then
             deck = powersDiscardZone.getObjects()[1]
             deck.setPositionSmooth(powersZone.getPosition(), false, true)
             deck.setRotationSmooth(Vector(0, 180, 180), false, true)
             deck.shuffle()
             wt(0.5)
 
-            for i=cardsAdded+1, math.min(cardsAdded+deck.getQuantity(), count) do
+            for i=cardsAdded-offset+1, math.min(cardsAdded-offset+deck.getQuantity(), count) do
                 local tempCard = deck.takeObject({
                     position = powerDealCentre + cardPlaceOffset[offset + i],
                     flip = true,

--- a/script.lua
+++ b/script.lua
@@ -2142,7 +2142,7 @@ function DealPowerCards(player, cardCount, deckZone, discardZone, playtestDeckZo
                 Wait.condition(function() cardsResting = cardsResting + 1 end, function() return not deck.isSmoothMoving() end)
             end
         elseif deck.type == "Deck" then
-            for i=1, math.min(deck.getQuantity(), count) do
+            for _=1, math.min(deck.getQuantity(), count) do
                 local tempCard = deck.takeObject({
                     position = powerDealCentre + cardPlaceOffset[cardsAdded + 1],
                     flip = true,

--- a/script.lua
+++ b/script.lua
@@ -2083,6 +2083,11 @@ function startDealPowerCards(minor, player, cardCount)
     startLuaCoroutine(Global, "startDealPowerCardsCo")
 end
 function DealPowerCards(player, cardCount, deckZone, discardZone, playtestDeckZone, playtestDiscardZone, playtestPowers)
+    local deckObj = deckZone.getObjects()[1]
+    local discardObj = discardZone.getObjects()[1]
+    local playtestDeckObj = playtestDeckZone.getObjects()[1]
+    local playtestDiscardObj = playtestDiscardZone.getObjects()[1]
+
     -- clear the zone!
     local hand = player.getHandTransform()
     if hand == nil then
@@ -2111,8 +2116,7 @@ function DealPowerCards(player, cardCount, deckZone, discardZone, playtestDeckZo
     local cardsResting = 0
     local powerDealCentre = handOffset + handPos
 
-    local function dealPowerCards(powersZone, powersDiscardZone, count, isPlaytest)
-        local deck = powersZone.getObjects()[1]
+    local function dealPowerCards(deck, discard, deckPos, count, isPlaytest)
         if deck == nil then
         elseif deck.type == "Card" then
             if count > 0 then
@@ -2143,16 +2147,13 @@ function DealPowerCards(player, cardCount, deckZone, discardZone, playtestDeckZo
                 Wait.condition(function() cardsResting = cardsResting + 1 end, function() return not tempCard.isSmoothMoving() end)
             end
         end
-        if count > 0 then
-            local discardDeck = powersDiscardZone.getObjects()[1]
-            if discardDeck ~= nil then
-                discardDeck.setPositionSmooth(powersZone.getPosition(), false, true)
-                discardDeck.setRotationSmooth(Vector(0, 180, 180), false, true)
-                discardDeck.shuffle()
-                wt(0.5)
+        if count > 0 and discard ~= nil then
+            discard.setPositionSmooth(deckPos, false, true)
+            discard.setRotationSmooth(Vector(0, 180, 180), false, true)
+            discard.shuffle()
+            wt(0.5)
 
-                dealPowerCards(powersZone, powersDiscardZone, count, isPlaytest)
-            end
+            dealPowerCards(discard, nil, deckPos, count, isPlaytest)
         end
     end
     local playtestCount = playtestPowers
@@ -2167,8 +2168,8 @@ function DealPowerCards(player, cardCount, deckZone, discardZone, playtestDeckZo
             playtestCount = 3
         end
     end
-    dealPowerCards(deckZone, discardZone, cardCount - playtestCount, false)
-    dealPowerCards(playtestDeckZone, playtestDiscardZone, playtestCount, true)
+    dealPowerCards(deckObj, discardObj, deckZone.getPosition(), cardCount - playtestCount, false)
+    dealPowerCards(playtestDeckObj, playtestDiscardObj, playtestDeckZone.getPosition(), playtestCount, true)
 
     Wait.condition(function() scriptWorkingCardC = false end, function() return cardsResting == cardsAdded end)
 end

--- a/script.lua
+++ b/script.lua
@@ -2111,25 +2111,26 @@ function DealPowerCards(player, cardCount, deckZone, discardZone, playtestDeckZo
     local cardsResting = 0
     local powerDealCentre = handOffset + handPos
 
-    local function dealPowerCards(powersZone, powersDiscardZone, count, offset, isPlaytest)
+    local function dealPowerCards(powersZone, powersDiscardZone, count, isPlaytest)
         local deck = powersZone.getObjects()[1]
         if deck == nil then
         elseif deck.type == "Card" then
-            if cardsAdded - offset < count then
+            if count > 0 then
                 deck.setLock(true)
-                deck.setPositionSmooth(powerDealCentre + cardPlaceOffset[offset + 1])
+                deck.setPositionSmooth(powerDealCentre + cardPlaceOffset[cardsAdded + 1])
                 deck.setRotationSmooth(Vector(0, 180, 0))
                 if isPlaytest then
                     deck.addTag("Playtest")
                 end
                 CreatePickPowerButton(deck)
                 cardsAdded = cardsAdded + 1
+                count = count - 1
                 Wait.condition(function() cardsResting = cardsResting + 1 end, function() return not deck.isSmoothMoving() end)
             end
         elseif deck.type == "Deck" then
             for i=1, math.min(deck.getQuantity(), count) do
                 local tempCard = deck.takeObject({
-                    position = powerDealCentre + cardPlaceOffset[offset + i],
+                    position = powerDealCentre + cardPlaceOffset[cardsAdded + 1],
                     flip = true,
                     callback_function = CreatePickPowerButton,
                 })
@@ -2138,19 +2139,20 @@ function DealPowerCards(player, cardCount, deckZone, discardZone, playtestDeckZo
                     tempCard.addTag("Playtest")
                 end
                 cardsAdded = cardsAdded + 1
+                count = count - 1
                 Wait.condition(function() cardsResting = cardsResting + 1 end, function() return not tempCard.isSmoothMoving() end)
             end
         end
-        if cardsAdded - offset < count then
+        if count > 0 then
             deck = powersDiscardZone.getObjects()[1]
             deck.setPositionSmooth(powersZone.getPosition(), false, true)
             deck.setRotationSmooth(Vector(0, 180, 180), false, true)
             deck.shuffle()
             wt(0.5)
 
-            for i=cardsAdded-offset+1, math.min(cardsAdded-offset+deck.getQuantity(), count) do
+            for i=1, math.min(deck.getQuantity(), count) do
                 local tempCard = deck.takeObject({
-                    position = powerDealCentre + cardPlaceOffset[offset + i],
+                    position = powerDealCentre + cardPlaceOffset[cardsAdded + 1],
                     flip = true,
                     callback_function = CreatePickPowerButton,
                 })
@@ -2159,6 +2161,7 @@ function DealPowerCards(player, cardCount, deckZone, discardZone, playtestDeckZo
                     tempCard.addTag("Playtest")
                 end
                 cardsAdded = cardsAdded + 1
+                count = count - 1
                 Wait.condition(function() cardsResting = cardsResting + 1 end, function() return not tempCard.isSmoothMoving() end)
             end
         end
@@ -2175,8 +2178,8 @@ function DealPowerCards(player, cardCount, deckZone, discardZone, playtestDeckZo
             playtestCount = 3
         end
     end
-    dealPowerCards(deckZone, discardZone, cardCount - playtestCount, 0, false)
-    dealPowerCards(playtestDeckZone, playtestDiscardZone, playtestCount, cardCount - playtestCount, true)
+    dealPowerCards(deckZone, discardZone, cardCount - playtestCount, false)
+    dealPowerCards(playtestDeckZone, playtestDiscardZone, playtestCount, true)
 
     Wait.condition(function() scriptWorkingCardC = false end, function() return cardsResting == cardsAdded end)
 end

--- a/script.lua
+++ b/script.lua
@@ -2148,7 +2148,7 @@ function DealPowerCards(player, cardCount, deckZone, discardZone, playtestDeckZo
             deck.shuffle()
             wt(0.5)
 
-            for i=cardsAdded+1, math.min(deck.getQuantity(), count) do
+            for i=cardsAdded+1, math.min(cardsAdded+deck.getQuantity(), count) do
                 local tempCard = deck.takeObject({
                     position = powerDealCentre + cardPlaceOffset[offset + i],
                     flip = true,


### PR DESCRIPTION
Fix #138, fix #140 and fix #141. Also allow supplementing from the normal deck when the playtest deck + discard is empty, or vice versa.