### PR TITLE
Make grabSpiritMarkers() skip extant markers.

### DIFF
--- a/script.lua
+++ b/script.lua
@@ -7863,10 +7863,14 @@ function applySpiritContextMenuItems(spirit)
 end
 
 function grabSpiritMarkers()
+    local hasMarker = {}
+    for _,obj in pairs(getObjectsWithTag("Spirit Marker")) do
+        hasMarker[obj.getName()] = true
+    end
     for color,data in pairs(selectedColors) do
         if data.zone then
             for _, obj in ipairs(data.zone.getObjects()) do
-                if obj.hasTag("Spirit") then
+                if obj.hasTag("Spirit") and not hasMarker[obj.getName()] then
                     spawnSpiritMarker(color, obj)
                     break
                 end


### PR DESCRIPTION
Before spirit markers were automated, the global "Grab Spirit Markers" option wouldn't grab markers for those who already had them. Revert to that behaviour.

It's common in public lobbies for some players to pick their spirits, grab spirit markers, and use the spirit markers to begin putting dibs on boards. When the remaining players pick spirits, they then want to grab spirit markers. They could right-click their spirit panels specifically, but often use (or want to use) the global option, which creates duplicate markers for those who already have them.