### PR TITLE
Fix a bug when gaining powers without playtest powers.

### DIFF
--- a/script.lua
+++ b/script.lua
@@ -1850,6 +1850,8 @@ function getPlaytestCount(params)
         return math.max(1, math.floor(count / 3))
     elseif playtestPowers == 2 then
         return math.max(1, math.floor(count / 2))
+    else
+        return 0
     end
 end
 function SetupPlaytestPowerDeck(deck, name, option, callback)


### PR DESCRIPTION
2d72935390009e035f9d9508bbb8810786bf04e1 completely broke gaining powers when playtest powers were disabled. *Mea culpa*.