### PR TITLE
Preserve hand GUIDs when swapping colours.

### DIFF
--- a/script.lua
+++ b/script.lua
@@ -7454,8 +7454,8 @@ function recolorPlayerArea(a, b)
                 found = true
             end
             if found then
-                spawnObjectData({data = data})
                 obj.destruct()
+                spawnObjectData({data = data})
             end
         end
     end


### PR DESCRIPTION
Changing the colour of a hand requires destructing and respawning it. Previously, the new hand was being spawned one line of code before the old hand was destructed. As such, the GUID of the hand was still occupied by the old copy of the hand. Swapping these lines, to destruct the old hand before spawning the new, allows the new hand to use the GUID of the old hand, preserving GUID.

The changing GUIDs don't cause any problems in the current mod, as hands are always accessed by index rather than GUID. However, this is an issue I ran into when writing stuff for the NI. I could get around the changing GUIDs, but it's such a simple fix, with no side-effects as far as I can tell, that I figure it may as well be changed here.