### PR TITLE
Refactor ready helper code to improve encapsulation.

### DIFF
--- a/objects/aidBoard/script.lua
+++ b/objects/aidBoard/script.lua
@@ -906,33 +906,35 @@ end
 
 function scanReady()
     local selectedColors = Global.getVar("selectedColors")
+    local seatTables = Global.getVar("seatTables")
     local yes = {}
     local no = {}
     local tints = Global.getTable("Tints")
-    for _,data in pairs(playerReadyGuids) do
+    for i,data in pairs(playerReadyGuids) do
         local readyToken = getObjectFromGUID(data.guid)
-        if data.color and selectedColors[data.color] then
-            local tokenTint = tints[data.color].Presence
-            if tints[data.color].Token then
-                tokenTint = tints[data.color].Token
+        local color = Global.call("getTableColor", getObjectFromGUID(seatTables[i]))
+        if color ~= "" and selectedColors[color] then
+            local tokenTint = tints[color].Presence
+            if tints[color].Token then
+                tokenTint = tints[color].Token
             end
             readyToken.setInvisibleTo({})
             readyToken.setColorTint(Color.fromHex(tokenTint))
 
-            if selectedColors[data.color].ready and selectedColors[data.color].ready.is_face_down then
+            if selectedColors[color].ready and selectedColors[color].ready.is_face_down then
                 readyToken.editButton({
                     index=0,
                     label="✓",
                     font_color="Green",
                 })
-                table.insert(yes, data.color)
+                table.insert(yes, color)
             else
                 readyToken.editButton({
                     index=0,
                     label="X",
                     font_color="Red",
                 })
-                table.insert(no, data.color)
+                table.insert(no, color)
             end
         else
             readyToken.setInvisibleTo(Player.getColors())

--- a/script.lua
+++ b/script.lua
@@ -3819,18 +3819,6 @@ function pickSpirit(params)
     SetupChecker.call("removeSpirit", params)
 end
 function removeSpirit(params)
-    local seatGuid = playerTables[params.color].guid
-    for index,guid in pairs(seatTables) do
-        if guid == seatGuid then
-            local playerReadyGuids = aidBoard.getTable("playerReadyGuids")
-            if index <= #playerReadyGuids then
-                playerReadyGuids[index].color = params.color
-                aidBoard.setTable("playerReadyGuids", playerReadyGuids)
-            end
-            break
-        end
-    end
-
     selectedColors[params.color] = {
         ready = params.ready,
         counter = params.counter,
@@ -7265,22 +7253,13 @@ function swapPlayerTables(a, b)
     a.setPosition(b.getPosition())
     b.setPosition(pos)
 
-    local indexA, indexB
     for i,guid in pairs(seatTables) do
         if guid == a.guid then
-            indexB = i
             seatTables[i] = b.guid
         elseif guid == b.guid then
-            indexA = i
             seatTables[i] = a.guid
         end
     end
-
-    local playerReadyGuids = aidBoard.getTable("playerReadyGuids")
-    local color = playerReadyGuids[indexA].color
-    playerReadyGuids[indexA].color = playerReadyGuids[indexB].color
-    playerReadyGuids[indexB].color = color
-    aidBoard.setTable("playerReadyGuids", playerReadyGuids)
 end
 
 function swapSeatColors(a, b)
@@ -7506,16 +7485,6 @@ function recolorPlayerArea(a, b)
         playerTables[b].setColorTint(colorTint)
     end
     playerTables[a], playerTables[b] = playerTables[b], playerTables[a]
-
-    local playerReadyGuids = aidBoard.getTable("playerReadyGuids")
-    for _,data in pairs(playerReadyGuids) do
-        if data.color == a then
-            data.color = b
-        elseif data.color == b then
-            data.color = a
-        end
-    end
-    aidBoard.setTable("playerReadyGuids", playerReadyGuids)
 
     updateSwapButtons()
 end


### PR DESCRIPTION
aidBoard's playerReadyGuids table didn't *just* store GUIDs, but the Global code also maintained a set of associated colours in there. This is a bad violation of encapsulation, and it's very difficult to tell, just reading the aidBoard code, where all the stored colours come from. Fix this by having Global never touch playerReadyGuids, and having aidBoard derive the required information directly from Global's seatTables variable. In doing so, fix #154, as information is no longer stored in playerReadyGuids that will be lost on save and reload.