### PR TITLE
Make random doubles tend to equal levels when maxed.

### DIFF
--- a/script.lua
+++ b/script.lua
@@ -1228,7 +1228,7 @@ function randomAdversary(attempts)
                 params.support = w
                 local newDiff = SetupChecker.call("difficultyCheck", params)
                 if newDiff >= randomMin and newDiff <= randomMax then
-                    table.insert(combos, {i,j})
+                    table.insert(combos, {leadingLevel = i, supportingLevel = j, sortKey = v + w})
                 elseif newDiff > randomMax then
                     break
                 end
@@ -1237,14 +1237,15 @@ function randomAdversary(attempts)
         if #combos ~= 0 then
             local index
             if randomMaximizeLevel then
+                table.sort(combos, function(a, b) return a.sortKey < b.sortKey end)
                 index = #combos
             else
                 index = math.random(1,#combos)
             end
             adversaryCard = adversary
-            adversaryLevel = combos[index][1]
+            adversaryLevel = combos[index].leadingLevel
             adversaryCard2 = adversary2
-            adversaryLevel2 = combos[index][2]
+            adversaryLevel2 = combos[index].supportingLevel
             SetupChecker.call("updateDifficulty")
             printToAll("Adversaries - "..adversaryCard.getName().." "..adversaryLevel.." and "..adversaryCard2.getName().." "..adversaryLevel2, Color.SoftBlue)
         else


### PR DESCRIPTION
That is, when using "maximise adversary level" with random double adversaries, prefer combinations like 4/4 to 6/0.

As it stands, the "maximise adversary level" option is pretty useless with random double adversaries. It maximises the level of the leading adversary first, then the level of the supporting adversary given that. As such, it almost always produces combinations with the supporting adversary at level 0 or level 1 (unless you pump the difficulty level up above what single adversaries can provide). In my experience, this isn't what people are playing double adversaries looking for. A 6/0 game is practically the same as a single adversary game, while something like a 4/4 game is a much more interesting combination (that often shakes out around the same difficulty).

With this change, a given pair of adversaries with a given max difficulty will still always produce the same combination (unlike prior to 8f21397cf882c9afa945c17c660615763a970d4c). However, it will tend towards more equal levels for the two adversaries. I do this just by picking the combination with the highest summed difficulty of the two adversaries (without the halving that's involved in the difficulty calculation).