### PR TITLE
Set rotation explicitly when dealing cards.

### DIFF
--- a/script.lua
+++ b/script.lua
@@ -2178,7 +2178,7 @@ function DealPowerCards(player, cardCount, deckZone, discardZone, playtestDeckZo
             for _=1, math.min(deck.getQuantity(), count) do
                 local tempCard = deck.takeObject({
                     position = powerDealCentre + cardPlaceOffset[cardsAdded + 1],
-                    flip = true,
+                    rotation = Vector(0, 180, 0),
                     callback_function = CreatePickPowerButton,
                 })
                 tempCard.setLock(true)


### PR DESCRIPTION
Someone reported a bug that the power cards they gained were appearing face down. They had the deck face-up, and dealing flips the cards. They shouldn't really have the deck face-up, but it seems no trouble to explicitly set the rotation when dealing cards, rather than simply flipping them.