### PR TITLE
Add a method for prioritizing modify triggers.

### DIFF
--- a/CUSTOM.md
+++ b/CUSTOM.md
@@ -421,7 +421,7 @@ This section is meant for users who are familiar with both the tts mod and progr
       - `color`: **string** - is the color of the player whose elements are being counted
       - `elements`: **table** - a table of eight numbers, representing the number of each element in order, indexed by numbers 1-8 (1: Sun, 2: Moon, 3: Fire, 4: Air, 5: Water, 6: Earth, 7: Plant, 8: Animal)
     - return **table** - the `elements` table, modified appropriately
-- Trigger to modify a elemental thresholds
+- Trigger to modify elemental thresholds
   - Create object and tag with "Modify Thresholds"
   - `modifyThresholds(params)`
     - `params`: **table** - contains data about the threshold

--- a/CUSTOM.md
+++ b/CUSTOM.md
@@ -391,6 +391,7 @@ This section is meant for users who are familiar with both the tts mod and progr
       - `costs`: **table** - maps card GUIDs (as keys) to costs (as values)
     - return **table** - the `costs` table, modified appropriately
       - e.g. Blitz would reduce the cost of all fast cards by 1, cards could be ignored in cost calculations by deleting them from the table
+  - Prioritized by `modifyCostPriority`
 - Trigger to modify the energy gained with the "Gain" button
   - Create object and tag with "Modify Gain"
   - `modifyGain(params)`
@@ -398,6 +399,7 @@ This section is meant for users who are familiar with both the tts mod and progr
       - `color`: **string** - is the color of the player who is gaining energy
       - `amount`: **number** - baseline amount of energy to gain (before bargain deductions)
     - return **number** - modified amount of energy to gain (before bargain deductions)
+  - Prioritized by `modifyGainPriority`
 - Trigger to run when a player successfully gains/pays energy (or successfully undoes these operations)
   - Create object and tag with "Gain Pay"
   - `onGainPay(params)`
@@ -414,6 +416,7 @@ This section is meant for users who are familiar with both the tts mod and progr
       - `major`: **boolean** - true if gaining majors, false if gaining minors
       - `count`: **number** - the number of cards being gained
     - return **number** - the number of cards to gain
+  - Prioritized by `modifyCardGainPriority`
 - Trigger to modify how a spirit's elements are counted
   - Create object and tag with "Modify Elements"
   - `modifyElements(params)`
@@ -421,6 +424,7 @@ This section is meant for users who are familiar with both the tts mod and progr
       - `color`: **string** - is the color of the player whose elements are being counted
       - `elements`: **table** - a table of eight numbers, representing the number of each element in order, indexed by numbers 1-8 (1: Sun, 2: Moon, 3: Fire, 4: Air, 5: Water, 6: Earth, 7: Plant, 8: Animal)
     - return **table** - the `elements` table, modified appropriately
+  - Prioritized by `modifyElementsPriority`
 - Trigger to modify elemental thresholds
   - Create object and tag with "Modify Thresholds"
   - `modifyThresholds(params)`
@@ -429,3 +433,11 @@ This section is meant for users who are familiar with both the tts mod and progr
       - `object`: **object reference** - the object on which the threshold sits (e.g. spirit panel, aspect card, power card)
       - `elements`: **table** - a table of eight numbers, representing the number of each element in order, indexed by numbers 1-8 (1: Sun, 2: Moon, 3: Fire, 4: Air, 5: Water, 6: Earth, 7: Plant, 8: Animal)
     - return **table** - the `elements` table, modified appropriately
+  - Prioritized by `modifyThresholdsPriority`
+
+#### Trigger Prioritization
+- Some triggers can be prioritized to ensure they're called in the correct order
+  - Define a variable (name specified above) on the object with the trigger function, set to a number
+  - Triggers with a higher number are run first
+  - Triggers with the same number are run an unspecified order
+  - Triggers with no defined priority are run after all others, in an unspecified order

--- a/objects/1b39da/script.lua
+++ b/objects/1b39da/script.lua
@@ -8,6 +8,7 @@ function Broadcast(params)
     return "Blitz - Remember, Invaders get an additional set of Actions at the end of Setup"
 end
 
+modifyCostPriority = 10
 function modifyCost(params)
     if Global.getVar("gameStarted") and Global.getVar("scenarioCard") ~= nil and Global.getVar("scenarioCard").guid == self.guid then
         for guid,cost in pairs(params.costs) do

--- a/objects/BnCBag/contained/788333/contained/495c9a/script.lua
+++ b/objects/BnCBag/contained/788333/contained/495c9a/script.lua
@@ -1,5 +1,6 @@
 blight=2
 
+modifyGainPriority = 5
 function modifyGain(params)
     if Global.getVar("blightedIsland") and Global.getVar("blightedIslandCard").guid == self.guid then
         return params.amount + 1

--- a/script.lua
+++ b/script.lua
@@ -992,6 +992,17 @@ end
 function isThematic()
     return boardLayout == "Thematic" or boardLayout == "Custom Thematic"
 end
+function getTriggers(tag, priorityVarName)
+    local function getPriority(obj)
+        local priority = obj.getVar(priorityVarName)
+        if priority == nil then
+            return -math.huge
+        else
+            return priority
+        end
+    end
+    return table.sort(getObjectsWithTag(tag), function(a, b) return getPriority(a) > getPriority(b) end)
+end
 ---- Setup Buttons Section
 function nullFunc()
 end
@@ -2062,7 +2073,7 @@ function MinorPowerUI(player, button)
     startDealPowerCards({player = player, major = false, count = cards})
 end
 function modifyCardGain(params)
-    for _,obj in pairs(getObjectsWithTag("Modify Card Gain")) do
+    for _,obj in ipairs(getTriggers("Modify Card Gain", "modifyCardGainPriority")) do
         params.count = obj.call("modifyCardGain", params)
     end
     return params.count
@@ -5728,13 +5739,13 @@ function Elements:__tostring()
 end
 
 local function modifyElements(params)
-    for _,object in pairs(getObjectsWithTag("Modify Elements")) do
+    for _,object in ipairs(getTriggers("Modify Elements", "modifyElementsPriority")) do
         params.elements = object.call("modifyElements", params)
     end
     return Elements:new(params.elements)
 end
 local function modifyThresholds(params)
-    for _,object in pairs(getObjectsWithTag("Modify Thresholds")) do
+    for _,object in ipairs(getTriggers("Modify Thresholds", "modifyThresholdsPriority")) do
         params.elements = object.call("modifyThresholds", params)
     end
     return Elements:new(params.elements)
@@ -6025,7 +6036,7 @@ function reclaimAll(target_obj, source_color)
     end
 end
 function modifyCost(params)
-    for _,object in pairs(getObjectsWithTag("Modify Cost")) do
+    for _,object in ipairs(getTriggers("Modify Cost", "modifyCostPriority")) do
         if not object.spawning then
             params.costs = object.call("modifyCost", params)
         end
@@ -6033,7 +6044,7 @@ function modifyCost(params)
     return params.costs
 end
 function modifyGain(params)
-    for _,object in pairs(getObjectsWithTag("Modify Gain")) do
+    for _,object in ipairs(getTriggers("Modify Gain", "modifyGainPriority")) do
         params.amount = object.call("modifyGain", params)
     end
     return params.amount


### PR DESCRIPTION
For some of the triggers we've added recently, it can matter which order they're called in, but currently that order is undefined, and indeed unstable. This is something that concerned me when I was writing them, but I didn't have a good solution at the time.

The specific case that's prompted me to write this fix is the scripting Emily's power card rework. She was asking this about writing a script that would make it so that, by default, you draft three cards instead of four. Exactly the sort of thing that `modifyCardGain()` is good for: it should be a simple "if you'd draw four, instead draw three". Except that there's a possibility of conflict with Mentor: specifically if Mentor receives Boon of Reimagining, then if matters which trigger runs first. Running Emily's, then Mentor's results in four cards, but running Mentor's then Emily's results in three. And this order isn't stable. The problem would be even worse if it was modifying up to five, instead of down to three: then it would matter which triggered first even on default drafts (one order would yield two cards, the other three).

Currently, I've added prioritisation only for the modify triggers (`modifyGain`, `modifyCost`, `modifyCardGain`, `modifyElements` and `modifyThresholds`). In theory, prioritisation could be relevant for other triggers, e.g. the time passes trigger. But I suspect that anything on those triggers that requires prioritisation will also require wait calls between successive runs, and that seems far too complicated to be getting into until there's an actual use case.