### PR TITLE
Update the images for Roiling Bog and Consuming Void.

### DIFF
--- a/objects/BnCBag/contained/c25a68/object.json
+++ b/objects/BnCBag/contained/c25a68/object.json
@@ -46,7 +46,7 @@
   "SidewaysCard": false,
   "CustomDeck": {
     "1520": {
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/1938265667438481114/38E5E5C6AACFCA1DF9DC7A7A36D189F4778ACD08/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2044121906863077745/C9654AEBFF6AC8DA5B5395BFC5361819179BC1A3/",
       "BackURL": "http://cloud-3.steamusercontent.com/ugc/2050875404517305126/48D7B7BFCF9AC4267E6E624C3915466A4BCFA580/",
       "NumWidth": 1,
       "NumHeight": 1,

--- a/objects/JEBag/contained/98a916/contained/f0e64c/object.json
+++ b/objects/JEBag/contained/98a916/contained/f0e64c/object.json
@@ -46,7 +46,7 @@
   "SidewaysCard": false,
   "CustomDeck": {
     "1236": {
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2050875404517296163/43DF9156C100811C89BC0B342E6C37CE2B2FE317/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2044121906863077467/9A9A2C8493492CB4A6797D7A577AFE576398C8C4/",
       "BackURL": "http://cloud-3.steamusercontent.com/ugc/2050875404517284371/15D525832E50C283329543A485C01FE9B65E7C2A/",
       "NumWidth": 1,
       "NumHeight": 1,

--- a/objects/JEBag/contained/98a916/object.json
+++ b/objects/JEBag/contained/98a916/object.json
@@ -138,7 +138,7 @@
       "Type": 0
     },
     "1236": {
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2050875404517296163/43DF9156C100811C89BC0B342E6C37CE2B2FE317/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2044121906863077467/9A9A2C8493492CB4A6797D7A577AFE576398C8C4/",
       "BackURL": "http://cloud-3.steamusercontent.com/ugc/2050875404517284371/15D525832E50C283329543A485C01FE9B65E7C2A/",
       "NumWidth": 1,
       "NumHeight": 1,


### PR DESCRIPTION
To, respectively:
- Remove the "Dahan cannot Move out of target land" line that was on the version of Bog previewed in the Backerkit but not in the version printed in NI, and
- Include the "from any spirit" note for the presence gather on the version of Void that was printed with NI.