### PR TITLE
Power/Spirit Editor Fixes

### DIFF
--- a/objects/Editors/contained/02413e/script.lua
+++ b/objects/Editors/contained/02413e/script.lua
@@ -127,7 +127,7 @@ function updateElements(player)
     state.trackElements = trackElements
     currentSpirit.script_state = JSON.encode(state)
     currentSpirit.setTable("trackElements", trackElements)
-    player.broadcast("Updated Elemental Thresholds for " .. currentSpiritName, Color.SoftBlue)
+    player.broadcast("Updated Elements for " .. currentSpiritName, Color.SoftBlue)
 end
 
 function populateElements(player)

--- a/objects/Editors/contained/02413e/script.lua
+++ b/objects/Editors/contained/02413e/script.lua
@@ -25,7 +25,7 @@ function scan()
         return
     end
     currentSpirit = objs[1]
-    currentSpiritName = currentSpirit.getName() 
+    currentSpiritName = currentSpirit.getName()
     if currentSpiritName == "" then
         currentSpiritName = "an unnamed Spirit"
     end

--- a/objects/Editors/contained/02413e/script.lua
+++ b/objects/Editors/contained/02413e/script.lua
@@ -1,5 +1,6 @@
 local rescan
 local currentSpirit
+local currentSpiritName
 
 function onLoad()
     self.createButton({
@@ -24,6 +25,10 @@ function scan()
         return
     end
     currentSpirit = objs[1]
+    currentSpiritName = currentSpirit.getName() 
+    if currentSpiritName == "" then
+        currentSpiritName = "an unnamed Spirit"
+    end
     if rescan or #self.getButtons() == 1 then
         rescan = false
         createButtons(currentSpirit)
@@ -122,11 +127,15 @@ function updateElements(player)
     state.trackElements = trackElements
     currentSpirit.script_state = JSON.encode(state)
     currentSpirit.setTable("trackElements", trackElements)
-    player.broadcast("Updated Elements for " .. currentSpirit.getName(), Color.SoftBlue)
+    player.broadcast("Updated Elemental Thresholds for " .. currentSpiritName, Color.SoftBlue)
 end
 
-function populateElements()
+function populateElements(player)
     if currentSpirit == nil then
+        return
+    end
+    if currentSpirit.is_face_down then
+        player.broadcast("Flip the Spirit Panel first", Color.SoftYellow)
         return
     end
     local trackElements = currentSpirit.getTable("trackElements")
@@ -182,11 +191,15 @@ function updateEnergy(player)
     currentSpirit.script_state = JSON.encode(state)
     currentSpirit.setTable("trackEnergy", trackEnergy)
     currentSpirit.setTable("bonusEnergy", bonusEnergy)
-    player.broadcast("Updated Energy for " .. currentSpirit.getName(), Color.SoftBlue)
+    player.broadcast("Updated Energy for " .. currentSpiritName, Color.SoftBlue)
 end
 
-function populateEnergy()
+function populateEnergy(player)
     if currentSpirit == nil then
+        return
+    end
+    if currentSpirit.is_face_down then
+        player.broadcast("Flip the Spirit Panel first", Color.SoftYellow)
         return
     end
     local trackEnergy = currentSpirit.getTable("trackEnergy")
@@ -246,12 +259,15 @@ function updateThreshold(player)
     state.thresholds = thresholds
     currentSpirit.script_state = JSON.encode(state)
     currentSpirit.setTable("thresholds", thresholds)
-
-    player.broadcast("Updated Elemental Thresholds for " .. currentSpirit.getName(), Color.SoftBlue)
+    player.broadcast("Updated Elemental Thresholds for " .. currentSpiritName, Color.SoftBlue)
 end
 
-function populateThreshold()
+function populateThreshold(player)
     if currentSpirit == nil then
+        return
+    end
+    if currentSpirit.is_face_down then
+        player.broadcast("Flip the Spirit Panel first", Color.SoftYellow)
         return
     end
     local thresholds = currentSpirit.getTable("thresholds")
@@ -298,7 +314,7 @@ function updateReminder(player)
     if location == nil then
         opString = "Reset"
     end
-    player.broadcast(opString .. " Reminder for " .. currentSpirit.getName(), Color.SoftBlue)
+    player.broadcast(opString .. " Reminder for " .. currentSpiritName, Color.SoftBlue)
 end
 
 function populateReminder(player)
@@ -309,12 +325,10 @@ function populateReminder(player)
     if location == nil then
         return
     end
-
     if (location.field == "ImageURL" and currentSpirit.is_face_down) or (location.field == "ImageSecondaryURL" and not currentSpirit.is_face_down) then
         player.broadcast("Flip the Spirit Panel first", Color.SoftYellow)
         return
     end
-
     local reminderBag = getObjectFromGUID("76f826")
     reminderBag.takeObject{
         smooth = false,

--- a/objects/Editors/contained/9207a4/script.lua
+++ b/objects/Editors/contained/9207a4/script.lua
@@ -33,10 +33,10 @@ function scan()
     if rescan or #self.getButtons() == 1 then
         rescan = false
         currentCard = objs[1]
-        currentCardName = currentCard.getName() 
+        currentCardName = currentCard.getName()
         if currentCardName == "" then
             currentCardName = "an unnamed Power Card"
-        end 
+        end
         local energy = 0
         if currentCard.getVar("energy") ~= nil then
             energy = currentCard.getVar("energy")
@@ -495,7 +495,7 @@ function updateReminder(player)
 
     player.broadcast(opString .. " Reminder for " .. currentCardName, Color.SoftBlue)
 end
-function populateReminder()
+function populateReminder(player)
     if currentCard == nil then
         return
     end

--- a/objects/Editors/contained/9207a4/script.lua
+++ b/objects/Editors/contained/9207a4/script.lua
@@ -392,9 +392,8 @@ function ensureScriptState(keys)
     end
 
     for _, key in ipairs(keys) do
-        local k = tostring(key)
-        if not state[k] then
-            state[k] = {}
+        if not state[key] then
+            state[key] = {}
         end
     end
 
@@ -504,7 +503,7 @@ function populateReminder(player)
         return
     end
     if (location.field == "ImageURL" and currentCard.is_face_down) or (location.field == "ImageSecondaryURL" and not currentCard.is_face_down) then
-        player.broadcast("Flip the Spirit Panel first", Color.SoftYellow)
+        player.broadcast("Flip the Power Card first", Color.SoftYellow)
         return
     end
 

--- a/objects/Editors/contained/9207a4/script.lua
+++ b/objects/Editors/contained/9207a4/script.lua
@@ -3,6 +3,7 @@ speeds = {"Fast", "Slow"}
 
 local rescan
 local currentCard
+local currentCardName
 
 function onLoad()
     self.createButton({
@@ -32,6 +33,10 @@ function scan()
     if rescan or #self.getButtons() == 1 then
         rescan = false
         currentCard = objs[1]
+        currentCardName = currentCard.getName() 
+        if currentCardName == "" then
+            currentCardName = "an unnamed Power Card"
+        end 
         local energy = 0
         if currentCard.getVar("energy") ~= nil then
             energy = currentCard.getVar("energy")
@@ -380,10 +385,27 @@ end
 ---
 cardLoadingScript = "function onLoad(saved_data)\n    if saved_data ~= \"\" then\n        local loaded_data = JSON.decode(saved_data)\n        self.setTable(\"thresholds\", loaded_data.thresholds)\n    end\nend\n-- card loading end"
 
+function ensureScriptState(keys)
+    local state = {}
+    if currentCard.script_state and currentCard.script_state ~= "" then
+        state = JSON.decode(currentCard.script_state)
+    end
+
+    for _, key in ipairs(keys) do
+        local k = tostring(key)
+        if not state[k] then
+            state[k] = {}
+        end
+    end
+
+    currentCard.script_state = JSON.encode(state)
+end
+
 function updateThreshold(player)
     if currentCard == nil then
         return
     end
+    ensureScriptState({"thresholds"})
     local thresholds = {}
     local hits = upCast(currentCard, 1, 0, {"Generic"}, "Threshold Marker")
     for _, hit in pairs(hits) do
@@ -417,7 +439,8 @@ function updateThreshold(player)
         end
         currentCard.setLuaScript(script)
     end
-    player.broadcast("Updated Elemental Thresholds for " .. currentCard.getName(), Color.SoftBlue)
+
+    player.broadcast("Updated Elemental Thresholds for " .. currentCardName, Color.SoftBlue)
 end
 
 function populateThreshold()
@@ -450,6 +473,7 @@ function updateReminder(player)
     if currentCard == nil then
         return
     end
+    ensureScriptState({"reminder"})
     local hits = upCast(currentCard, 1, 0, {"Generic"}, "Reminder Marker")
     local location = nil
     for _, entry in pairs(hits) do
@@ -468,7 +492,8 @@ function updateReminder(player)
     if location == nil then
         opString = "Reset"
     end
-    player.broadcast(opString .. " Reminder for " .. currentCard.getName(), Color.SoftBlue)
+
+    player.broadcast(opString .. " Reminder for " .. currentCardName, Color.SoftBlue)
 end
 function populateReminder()
     if currentCard == nil then
@@ -476,6 +501,10 @@ function populateReminder()
     end
     local location = Global.call("getReminderLocation", {obj = currentCard})
     if location == nil then
+        return
+    end
+    if (location.field == "ImageURL" and currentCard.is_face_down) or (location.field == "ImageSecondaryURL" and not currentCard.is_face_down) then
+        player.broadcast("Flip the Spirit Panel first", Color.SoftYellow)
         return
     end
 

--- a/objects/Editors/contained/d667fe/object.json
+++ b/objects/Editors/contained/d667fe/object.json
@@ -1,9 +1,9 @@
 {
   "Name": "3DText",
   "Transform": {
-    "posX": 105.2102,
+    "posX": 105.21,
     "posY": 0.96,
-    "posZ": 58.6501,
+    "posZ": 58.65,
     "rotX": 90.0,
     "rotY": 0.0,
     "rotZ": 0.0,


### PR DESCRIPTION
- Fixed just-imported cards running into errors when updating their Reminder or Thresholds. 
- Update buttons now refer to unnamed cards or spirits as 'an unnamed Power Card or Spirit' when broadcasting. 
- Populate buttons on the Spirit Editor now remind the player to flip the Spirit Panel over if needed.