### PR TITLE
Add a reroll option to Gain a Spirit and other misc improvements

### DIFF
--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -1975,6 +1975,7 @@ function setupGainSpiritChoices(obj, choices)
         })
     end
     if count > 0 then
+        table.insert(buttons, {tag = "Text"})
         table.insert(buttons, {
             tag = "Button",
             attributes = {
@@ -1982,9 +1983,9 @@ function setupGainSpiritChoices(obj, choices)
                 id = "reroll! " .. obj.guid,
                 text = "Reroll Spirit Choices",
                 onClick = "SetupChecker/gainSpirit(reroll)",
-                fontSize = "44",
-                minWidth = "800",
-                minHeight = "110",
+                fontSize = "36",
+                minWidth = "400",
+                minHeight = "80",
             },
         })
     end

--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -1966,7 +1966,7 @@ function setupGainSpiritChoices(obj, choices)
         table.insert(buttons, {
             tag = "Text",
             attributes = {
-                color="#FFFF00",
+                color = "#FFFF00",
                 text = "No other spirits available.",
                 fontSize = "44",
                 minWidth = "800",

--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -2058,7 +2058,7 @@ function getNewSpirit(tags, complexities)
     local spirit, candidate
     local count = 0  -- # of eligible spirits seen so far
     for _, guid in pairs(spiritGuids) do
-        local candidate = getObjectFromGUID(guid)
+        candidate = getObjectFromGUID(guid)
         if tags[spiritTags[guid]] and complexities[spiritComplexities[guid]] and not spiritChoices[candidate.getName()] then
             count = count + 1
             if math.random(1, count) == 1 then

--- a/objects/SetupChecker/script.lua
+++ b/objects/SetupChecker/script.lua
@@ -1975,7 +1975,7 @@ function setupGainSpiritChoices(obj, choices)
         })
     end
     if count > 0 then
-        table.insert(buttons, {tag = "Text"})
+        table.insert(buttons, {tag = "Text"})  -- Empty text to offset the reroll button from the spirit choices.
         table.insert(buttons, {
             tag = "Button",
             attributes = {


### PR DESCRIPTION
- Gain a Spirit now adds a "Reroll" button which returns the 4 chosen spirits to the pool and draws 4 new ones.
- When Gaining a Spirit chooses less than 4 spirits, add a "No other spirits available." message to the list.
- Update getNewSpirit to use reservoir sampling instead of a retry loop.
- It turns out getNewSpirit was the only thing that cared about spiritChoicesLength, so remove all things that referenced spiritChoicesLength
- Typo fix "Replacment" => "Replacement" in replaceSpirit()
- When choosing a Gain a Spirit option, return the unchosen three to the pool for other players to random into.